### PR TITLE
fix: remove parse information before submitting offline forms

### DIFF
--- a/modules/cached-resources/error-handling.js
+++ b/modules/cached-resources/error-handling.js
@@ -1,12 +1,12 @@
 import { Parse } from 'parse/react-native';
 import { retrieveSignInFunction } from '../../services/parse/auth';
-import { getData, deleteData, getAllData } from '../async-storage';
+import { getData, deleteData } from '../async-storage';
 
 export default function handleParseError(err, functionToCall) {
   return new Promise((resolve, reject) => {
     if (err.code === Parse.Error.INVALID_SESSION_TOKEN) {
       // delete local async parse informatin
-      deleteData("Parse/myAppId/currentUser").then(() => {
+      deleteData('Parse/myAppId/currentUser').then(() => {
         // get locally stored user information if credentials are saved
         getData('credentials').then((user) => {
           // sign in the user to retrieve fresh session token
@@ -19,7 +19,7 @@ export default function handleParseError(err, functionToCall) {
             reject(error);
           });
         });
-      })
+      });
     }
   });
 }

--- a/modules/cached-resources/error-handling.js
+++ b/modules/cached-resources/error-handling.js
@@ -1,19 +1,25 @@
 import { Parse } from 'parse/react-native';
 import { retrieveSignInFunction } from '../../services/parse/auth';
-import { getData } from '../async-storage';
+import { getData, deleteData, getAllData } from '../async-storage';
 
-export default async function handleParseError(err, functionToCall) {
+export default function handleParseError(err, functionToCall) {
   return new Promise((resolve, reject) => {
     if (err.code === Parse.Error.INVALID_SESSION_TOKEN) {
-      getData('credentials').then((user) => {
-        retrieveSignInFunction(user.username, user.password).then(() => {
-          functionToCall().then(() => {
-            resolve(true);
+      // delete local async parse informatin
+      deleteData("Parse/myAppId/currentUser").then(() => {
+        // get locally stored user information if credentials are saved
+        getData('credentials').then((user) => {
+          // sign in the user to retrieve fresh session token
+          retrieveSignInFunction(user.username, user.password).then(() => {
+            // resubmit offline forms
+            functionToCall().then(() => {
+              resolve(true);
+            });
+          }, (error) => {
+            reject(error);
           });
-        }, (error) => {
-          reject(error);
         });
-      });
+      })
     }
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "puente-reactnative",
-  "version": "9.0.0",
+  "version": "9.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
### Description of proposed changes
_What does this pull request accomplish? Why should it be integrated?_
removes the locally stored user information by parse, so that a session token can be refreshed
### Checklist
_Put an `x` in the boxes that apply._
- [ ] My lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my changes work (if applicable)
- [ ] I have added or updated necessary documentation (if appropriate)

### Additional comments
_Is there anything else you want us to know?_
