### PR TITLE
fix: legacy __ select options not appending answer from text question

### DIFF
--- a/domains/DataCollection/Forms/SupplementaryForm/utils/index.js
+++ b/domains/DataCollection/Forms/SupplementaryForm/utils/index.js
@@ -5,12 +5,11 @@ function addSelectTextInputs(values, formObject) {
       const keys = key.split('__');
       const formikKey = keys[1];
       const formikOrigVal = keys[2];
-      if(typeof(formObject[formikKey]) === 'object'){
+      if (typeof (formObject[formikKey]) === 'object') {
         const index = newFormObject[formikKey].indexOf(formikOrigVal);
         newFormObject[formikKey][index] = `${formikOrigVal}__${val}`;
         delete newFormObject[key];
-      }
-      else if (typeof(formObject[formikKey]) === 'string') {
+      } else if (typeof (formObject[formikKey]) === 'string') {
         newFormObject[formikKey] = `${formikOrigVal}__${val}`;
         delete newFormObject[key];
       }

--- a/domains/DataCollection/Forms/SupplementaryForm/utils/index.js
+++ b/domains/DataCollection/Forms/SupplementaryForm/utils/index.js
@@ -5,9 +5,15 @@ function addSelectTextInputs(values, formObject) {
       const keys = key.split('__');
       const formikKey = keys[1];
       const formikOrigVal = keys[2];
-      const index = newFormObject[formikKey].indexOf(formikOrigVal);
-      newFormObject[formikKey][index] = `${formikOrigVal}__${val}`;
-      delete newFormObject[key];
+      if(typeof(formObject[formikKey]) === 'object'){
+        const index = newFormObject[formikKey].indexOf(formikOrigVal);
+        newFormObject[formikKey][index] = `${formikOrigVal}__${val}`;
+        delete newFormObject[key];
+      }
+      else if (typeof(formObject[formikKey]) === 'string') {
+        newFormObject[formikKey] = `${formikOrigVal}__${val}`;
+        delete newFormObject[key];
+      }
     }
   });
   return formObject;


### PR DESCRIPTION
### Description of proposed changes
_What does this pull request accomplish? Why should it be integrated?_
Select textKey values nt appending to answer. this fixes that and ensures legacy '__' are handled correctly for any old forms we have made in the past using this method.
### Checklist
_Put an `x` in the boxes that apply._
- [x] My lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my changes work (if applicable)
- [ ] I have added or updated necessary documentation (if appropriate)

### Additional comments
_Is there anything else you want us to know?_
