### PR TITLE
Fix offline data collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [15.5.0](https://github.com/hopetambala/puente-reactnative-collect/compare/v15.4.1...v15.5.0) (2026-06-06)
+
+
+### New Features
+
+* add claude code that's appropriate ([3a8b0dd](https://github.com/hopetambala/puente-reactnative-collect/commit/3a8b0dd4b6a41bce8c0f0e3fe3ac4ed8d17acc0f))
+* update homescreen and fix onboarding issues ([f2f9084](https://github.com/hopetambala/puente-reactnative-collect/commit/f2f90848dffc5ea4d633fbd5ce44a3c45c617f4c))
+
+
+### Bug fixes
+
+* address auth, header, offline post, and stats service issues ([e74167b](https://github.com/hopetambala/puente-reactnative-collect/commit/e74167b28442331fc9135a21d23066e19cd837c2))
+* **offline:** restore offline data collection and upload flow ([6def89f](https://github.com/hopetambala/puente-reactnative-collect/commit/6def89fef02276405275916d674d78b930886e42))
+
 ### [15.4.1](https://github.com/hopetambala/puente-reactnative-collect/compare/v15.4.0...v15.4.1) (2026-05-06)
 
 

--- a/domains/Auth/PinCode/GetPinCode/index.js
+++ b/domains/Auth/PinCode/GetPinCode/index.js
@@ -16,44 +16,46 @@ function GetPinCode({ navigation }) {
     <Formik
       initialValues={{ pincode: "" }}
       onSubmit={(values, actions) => {
-        getData("pincode").then((pincode) => {
-          if (values.pincode === pincode) {
-            // IF ONLINE, otherwise just log in
-            checkOnlineStatus().then((connected) => {
-              if (connected) {
-                getData("currentUser").then(
-                  (asyncUser) => {
-                    retrieveSignInFunction(
-                      asyncUser.username,
-                      asyncUser.credentials.password
-                    ).then((signedInUser) => {
-                      populateCache(signedInUser);
-                    });
-                    navigation.navigate("Root");
-                  },
-                  () => {
-                    // error with stored currentUser
-                  }
-                );
-              } else {
-                navigation.navigate("Root");
-              }
-            });
-          } else {
-            setFailedAttempts(failedAttempts + 1);
-            // go back to sign in on 3rd attempt
-            if (failedAttempts >= 3) {
-              deleteData("currentUser");
-              deleteData("pincode");
-              deleteData("organization");
-              navigation.navigate("Sign In");
-            } else if (failedAttempts === 2) {
-              alert(I18n.t("pinCode.getPinCode.incorrect1")); // eslint-disable-line
+        getData("pincode")
+          .then((pincode) => {
+            if (values.pincode === pincode) {
+              // IF ONLINE, otherwise just log in
+              checkOnlineStatus().then((connected) => {
+                if (connected) {
+                  getData("currentUser").then(
+                    (asyncUser) => {
+                      retrieveSignInFunction(
+                        asyncUser.username,
+                        asyncUser.credentials.password
+                      ).then((signedInUser) => {
+                        populateCache(signedInUser);
+                      });
+                      navigation.navigate("Root");
+                    },
+                    () => {
+                      // error with stored currentUser
+                    }
+                  );
+                } else {
+                  navigation.navigate("Root");
+                }
+              });
             } else {
-              alert(I18n.t("pinCode.getPinCode.incorrect2")); // eslint-disable-line
+              setFailedAttempts(failedAttempts + 1);
+              // go back to sign in on 3rd attempt
+              if (failedAttempts >= 3) {
+                deleteData("currentUser");
+                deleteData("pincode");
+                deleteData("organization");
+                navigation.navigate("Sign In");
+              } else if (failedAttempts === 2) {
+                alert(I18n.t("pinCode.getPinCode.incorrect1")); // eslint-disable-line
+              } else {
+                alert(I18n.t("pinCode.getPinCode.incorrect2")); // eslint-disable-line
+              }
             }
-          }
-        });
+          })
+          .catch(() => {});
 
         setTimeout(() => {
           actions.setSubmitting(false);

--- a/domains/Auth/SignIn/index.js
+++ b/domains/Auth/SignIn/index.js
@@ -117,7 +117,7 @@ function SignIn({ navigation, route }) {
 
   useEffect(() => {
     async function checkLanguage() {
-      const currentLocale = await getData("locale");
+      const currentLocale = await getData("locale").catch(() => null);
 
       if (
         currentLocale !== "en" &&

--- a/domains/DataCollection/Forms/IdentificationForm/utils/index.js
+++ b/domains/DataCollection/Forms/IdentificationForm/utils/index.js
@@ -8,7 +8,7 @@ const backgroundPostPatient = () => {
   checkOnlineStatus().then((isConnected) => {
     // only post if connected to internet
     if (isConnected) {
-      getAllData().then((allAsyncData) => {
+      getAllData().catch(() => []).then((allAsyncData) => {
         // contains all the available keys
         const allKeys = allAsyncData.map((a) => a[0]);
         allKeys.forEach((item) => {

--- a/domains/FindRecords/ResidentRecordHistoryScreen.js
+++ b/domains/FindRecords/ResidentRecordHistoryScreen.js
@@ -57,7 +57,15 @@ const RECORD_TYPES = [
 
 const ResidentRecordHistoryScreen = ({ navigation, route }) => {
   const theme = useTheme();
-  const { resident } = route.params;
+  const { resident, fromTab } = route.params;
+
+  const handleBack = () => {
+    if (fromTab) {
+      navigation.getParent()?.navigate(fromTab);
+    } else {
+      navigation.goBack();
+    }
+  };
   const [recordsByType, setRecordsByType] = useState({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -170,7 +178,7 @@ const ResidentRecordHistoryScreen = ({ navigation, route }) => {
   if (loading) {
     return (
       <SafeAreaView edges={['top']} style={{ flex: 1, backgroundColor: theme.colors.background }} testID="loadingContainer">
-        <Button icon="arrow-left" onPress={() => navigation.goBack()} style={{ margin: 8 }}>{I18n.t('global.back')}</Button>
+        <Button icon="arrow-left" onPress={handleBack} style={{ margin: 8 }}>{I18n.t('global.back')}</Button>
         <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
           <ActivityIndicator size="large" color={theme.colors.primary} testID="loadingIndicator" />
           <Text style={{ color: theme.colors.onBackground }}>{I18n.t('residentHistory.loading')}</Text>
@@ -182,7 +190,7 @@ const ResidentRecordHistoryScreen = ({ navigation, route }) => {
   if (error) {
     return (
       <SafeAreaView edges={['top']} style={{ flex: 1, padding: 20, backgroundColor: theme.colors.background }} testID="error-view">
-        <Button icon="arrow-left" onPress={() => navigation.goBack()} style={{ marginBottom: 8 }}>{I18n.t('global.back')}</Button>
+        <Button icon="arrow-left" onPress={handleBack} style={{ marginBottom: 8 }}>{I18n.t('global.back')}</Button>
         <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
           <Text style={{ fontSize: 16, fontWeight: 'bold', marginBottom: 10, color: theme.colors.onBackground }}>
             {I18n.t('residentHistory.errorLoadingRecords')}
@@ -214,7 +222,7 @@ const ResidentRecordHistoryScreen = ({ navigation, route }) => {
   if (!hasRecords) {
     return (
       <SafeAreaView edges={['top']} style={{ flex: 1, padding: 20, backgroundColor: theme.colors.background }}>
-        <Button icon="arrow-left" onPress={() => navigation.goBack()} style={{ marginBottom: 8 }}>{I18n.t('global.back')}</Button>
+        <Button icon="arrow-left" onPress={handleBack} style={{ marginBottom: 8 }}>{I18n.t('global.back')}</Button>
         <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
           <Text style={{ fontSize: 16, fontWeight: 'bold', marginBottom: 10, color: theme.colors.onBackground }}>{I18n.t('residentHistory.noRecordsFound')}</Text>
           <Text style={{ textAlign: 'center', color: theme.colors.onSurfaceVariant }}>
@@ -229,7 +237,7 @@ const ResidentRecordHistoryScreen = ({ navigation, route }) => {
     <SafeAreaView edges={['top']} style={{ flex: 1, backgroundColor: theme.colors.background }}>
       <ScrollView style={{ flex: 1, padding: 16, backgroundColor: theme.colors.background }}>
         <View>
-          <Button icon="arrow-left" onPress={() => navigation.goBack()} style={{ marginBottom: 8, alignSelf: 'flex-start' }}>{I18n.t('global.back')}</Button>
+          <Button icon="arrow-left" onPress={handleBack} style={{ marginBottom: 8, alignSelf: 'flex-start' }}>{I18n.t('global.back')}</Button>
           <Text style={{ fontSize: 18, fontWeight: 'bold', marginBottom: 16, color: theme.colors.onBackground }}>
             {I18n.t('residentHistory.recordHistory')}
             {' '}

--- a/domains/FindRecords/__tests__/ResidentRecordHistoryScreen.test.js
+++ b/domains/FindRecords/__tests__/ResidentRecordHistoryScreen.test.js
@@ -5,7 +5,7 @@
 /* eslint-disable no-promise-executor-return, global-require */
 
 import ResidentRecordHistoryScreen from '@app/domains/FindRecords/ResidentRecordHistoryScreen';
-import { render, screen, waitFor } from '@testing-library/react-native';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import React from 'react';
 
 // Mock Parse query
@@ -498,6 +498,28 @@ describe('ResidentRecordHistoryScreen - RED-GREEN TDD', () => {
         expect(screen.getByText(/Dog Intake Form/)).toBeDefined();
         expect(screen.getByText(/Cat Adoption Survey/)).toBeDefined();
       });
+    });
+  });
+
+  describe('RED: fromTab back-navigation regression', () => {
+    test('pressing back with fromTab=Home should call navigation.getParent().navigate(Home) and NOT call goBack', () => {
+      const mockParentNavigate = jest.fn();
+      const mockGoBack = jest.fn();
+      const mockNavigation = {
+        goBack: mockGoBack,
+        getParent: jest.fn(() => ({ navigate: mockParentNavigate })),
+      };
+      const mockRoute = { params: { resident: mockResident, fromTab: 'Home' } };
+
+      render(<ResidentRecordHistoryScreen navigation={mockNavigation} route={mockRoute} />);
+
+      // The Button mock renders <button> (non-Text host element); getByText won't
+      // traverse into it, so we locate by children prop directly.
+      const [backButton] = screen.UNSAFE_getAllByProps({ children: 'global.back' });
+      fireEvent.press(backButton);
+
+      expect(mockParentNavigate).toHaveBeenCalledWith('Home');
+      expect(mockGoBack).not.toHaveBeenCalled();
     });
   });
 });

--- a/domains/HomeScreen/__test__/HomeScreen.integration.test.js
+++ b/domains/HomeScreen/__test__/HomeScreen.integration.test.js
@@ -3,6 +3,12 @@ import HomeScreen from '@app/domains/HomeScreen/index';
 import { fireEvent, render, waitFor } from '@testing-library/react-native';
 import React from 'react';
 
+const mockFetchResidentById = jest.fn(() => Promise.resolve(null));
+
+jest.mock('@impacto-design-system/Extensions/FindResidents/_utils', () => ({
+  fetchResidentById: (...args) => mockFetchResidentById(...args),
+}));
+
 // Mock Text component early to prevent theme loading errors
 jest.mock('@app/impacto-design-system/Base/Text', () => function MockText({ children, style }) {
   // eslint-disable-next-line global-require
@@ -15,18 +21,51 @@ jest.mock('@app/impacto-design-system/Base/Text', () => function MockText({ chil
 jest.mock('../hooks/useHomeStats', () => ({ __esModule: true, default: jest.fn() }));
 
 // Mock child components to keep HomeScreen render simple
-jest.mock('../components/StatCard', () => function MockStatCard({ title, count }) {
+jest.mock('../components/StatCard', () => function MockStatCard({ title, count, onPress }) {
   // eslint-disable-next-line global-require
   const { Text } = require('react-native');
   // eslint-disable-next-line global-require
-  return require('react').createElement(Text, {}, `${title}: ${count}`);
+  return require('react').createElement(Text, { onPress }, `${title}: ${count}`);
 });
 
-jest.mock('../components/StatDetailModal', () => function MockStatDetailModal() {
+jest.mock('../components/StatDetailModal', () => function MockStatDetailModal({ visible, onSurveyDataPress }) {
   // eslint-disable-next-line global-require
   const { Text } = require('react-native');
   // eslint-disable-next-line global-require
-  return require('react').createElement(Text, {}, 'Modal');
+  const ReactLib = require('react');
+  return ReactLib.createElement(
+    ReactLib.Fragment,
+    null,
+    ReactLib.createElement(Text, {}, 'Modal'),
+    visible
+      ? ReactLib.createElement(
+        Text,
+        {
+          accessibilityRole: 'button',
+          onPress: () => {
+            onSurveyDataPress?.({ resident: { objectId: 'resident-123' } });
+          },
+        },
+        'Open resident forms'
+      )
+      : null,
+    visible
+      ? ReactLib.createElement(
+        Text,
+        {
+          accessibilityRole: 'button',
+          onPress: () => {
+            onSurveyDataPress?.({
+              objectId: 'resident-123',
+              _parseClass: 'Survey',
+              label: 'My Survey Item',
+            });
+          },
+        },
+        'Open resident forms (item)'
+      )
+      : null
+  );
 });
 
 jest.mock('../components/CoachmarkOverlay', () => ({
@@ -152,6 +191,7 @@ const mockRefresh = jest.fn();
 describe('HomeScreen Component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockFetchResidentById.mockResolvedValue({ objectId: 'resident-123', firstname: 'Fresh Name' });
     useHomeStats.mockReturnValue({
       stats: mockStatsData,
       isLoading: false,
@@ -371,6 +411,75 @@ describe('HomeScreen Component', () => {
     await waitFor(() => {
       // StatCard mock renders title:count; verify a stat renders
       expect(getByText(/Activity across the Organization/i)).toBeDefined();
+    });
+  });
+
+  test('pressing a SurveyData row fetches resident, navigates to Find_Records -> ResidentRecordHistory, and closes modal', async () => {
+    const mockNavigate = jest.fn();
+    const navigation = { navigate: mockNavigate };
+
+    const { getByText, queryByText } = render(<HomeScreen navigation={navigation} />);
+
+    fireEvent.press(getByText(/My Surveys/i));
+    fireEvent.press(getByText('Open resident forms'));
+
+    await waitFor(() => {
+      expect(mockFetchResidentById).toHaveBeenCalledWith('resident-123');
+      expect(mockNavigate).toHaveBeenCalledWith('Find_Records', {
+        screen: 'ResidentRecordHistory',
+        params: {
+          resident: {
+            objectId: 'resident-123',
+            firstname: 'Fresh Name',
+          },
+        },
+      });
+      expect(queryByText('Open resident forms')).toBeNull();
+    });
+  });
+
+  test('shows Alert and does not navigate when fetchResidentById returns null', async () => {
+    // eslint-disable-next-line global-require
+    const { Alert } = require('react-native');
+    jest.spyOn(Alert, 'alert');
+
+    mockFetchResidentById.mockResolvedValueOnce(null);
+
+    const mockNavigate = jest.fn();
+    const navigation = { navigate: mockNavigate };
+
+    const { getByText } = render(<HomeScreen navigation={navigation} />);
+
+    fireEvent.press(getByText(/My Surveys/i));
+    fireEvent.press(getByText('Open resident forms'));
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalled();
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalledWith('Find_Records', expect.anything());
+  });
+
+  test('pressing a SurveyData item (flat payload) fetches resident by item.objectId and navigates', async () => {
+    const mockNavigate = jest.fn();
+    const navigation = { navigate: mockNavigate };
+
+    const { getByText } = render(<HomeScreen navigation={navigation} />);
+
+    fireEvent.press(getByText(/My Surveys/i));
+    fireEvent.press(getByText('Open resident forms (item)'));
+
+    await waitFor(() => {
+      expect(mockFetchResidentById).toHaveBeenCalledWith('resident-123');
+      expect(mockNavigate).toHaveBeenCalledWith('Find_Records', {
+        screen: 'ResidentRecordHistory',
+        params: {
+          resident: {
+            objectId: 'resident-123',
+            firstname: 'Fresh Name',
+          },
+        },
+      });
     });
   });
 });

--- a/domains/HomeScreen/__test__/HomeScreen.integration.test.js
+++ b/domains/HomeScreen/__test__/HomeScreen.integration.test.js
@@ -432,6 +432,7 @@ describe('HomeScreen Component', () => {
             objectId: 'resident-123',
             firstname: 'Fresh Name',
           },
+          fromTab: 'Home',
         },
       });
       expect(queryByText('Open resident forms')).toBeNull();
@@ -478,6 +479,7 @@ describe('HomeScreen Component', () => {
             objectId: 'resident-123',
             firstname: 'Fresh Name',
           },
+          fromTab: 'Home',
         },
       });
     });

--- a/domains/HomeScreen/components/StatDetailModal/__tests__/StatDetailModal.unit.test.js
+++ b/domains/HomeScreen/components/StatDetailModal/__tests__/StatDetailModal.unit.test.js
@@ -1,0 +1,149 @@
+import StatDetailModal from '@app/domains/HomeScreen/components/StatDetailModal';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import React from 'react';
+
+const mockReset = jest.fn();
+
+jest.mock('@app/domains/HomeScreen/hooks/useModalItems', () => jest.fn(() => ({
+  items: [
+    {
+      objectId: 'survey-1',
+      _parseClass: 'SurveyData',
+      label: 'Initial household survey',
+      createdAt: new Date('2026-06-01T12:00:00.000Z'),
+    },
+    {
+      objectId: 'vitals-1',
+      _parseClass: 'Vitals',
+      label: 'BP check',
+      createdAt: new Date('2026-06-01T13:00:00.000Z'),
+    },
+  ],
+  isLoading: false,
+  hasMore: false,
+  loadMore: jest.fn(),
+  reset: mockReset,
+})));
+
+jest.mock('@app/impacto-design-system/Base/Text', () => function MockText({ children, ...props }) {
+  // eslint-disable-next-line global-require
+  const { Text } = require('react-native');
+  return <Text {...props}>{children}</Text>;
+});
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => function MockIcon({ name }) {
+  // eslint-disable-next-line global-require
+  const { Text } = require('react-native');
+  return <Text>{name}</Text>;
+});
+
+jest.mock('react-native-paper', () => ({
+  useTheme: () => ({
+    colors: {
+      background: '#ffffff',
+      onSurface: '#111111',
+      onSurfaceVariant: '#444444',
+      primary: '#007AFF',
+    },
+  }),
+  Button: ({ children, onPress, disabled }) => {
+    // eslint-disable-next-line global-require
+    const ReactModule = require('react');
+    // eslint-disable-next-line global-require
+    const { Text } = require('react-native');
+    return ReactModule.createElement(Text, { onPress: disabled ? undefined : onPress }, children);
+  },
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+  }),
+}));
+
+jest.mock('react-native-reanimated', () => {
+  // eslint-disable-next-line global-require
+  const { View } = require('react-native');
+
+  class MockKeyframe {
+    delay() {
+      return this;
+    }
+
+    duration() {
+      return this;
+    }
+  }
+
+  return {
+    __esModule: true,
+    default: {
+      View,
+    },
+    Keyframe: MockKeyframe,
+  };
+});
+
+describe('StatDetailModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls onSurveyDataPress with the pressed item when a SurveyData row is tapped', () => {
+    const onSurveyDataPress = jest.fn();
+    render(
+      <StatDetailModal
+        visible
+        onClose={jest.fn()}
+        title="Recent Activity"
+        cardType="recentActivity"
+        timeFilter="last7"
+        onSurveyDataPress={onSurveyDataPress}
+      />
+    );
+
+    fireEvent.press(screen.getByRole('button', { name: /initial household survey/i }));
+
+    expect(onSurveyDataPress).toHaveBeenCalledTimes(1);
+    expect(onSurveyDataPress).toHaveBeenCalledWith(
+      expect.objectContaining({ objectId: 'survey-1', _parseClass: 'SurveyData' })
+    );
+  });
+
+  it('only makes SurveyData rows tappable and only SurveyData rows show a tappable signifier', () => {
+    render(
+      <StatDetailModal
+        visible
+        onClose={jest.fn()}
+        title="Recent Activity"
+        cardType="recentActivity"
+        timeFilter="last7"
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /initial household survey/i })).toBeTruthy();
+    expect(screen.getByLabelText(/open survey details/i)).toBeTruthy();
+
+    expect(screen.queryByRole('button', { name: /bp check/i })).toBeNull();
+    fireEvent.press(screen.getByText('BP check'));
+    expect(screen.queryByLabelText(/open survey details for bp check/i)).toBeNull();
+  });
+
+  it('displays a chevron-right icon next to "Open survey details" to signal the row is tappable', () => {
+    render(
+      <StatDetailModal
+        visible
+        onClose={jest.fn()}
+        title="Recent Activity"
+        cardType="recentActivity"
+        timeFilter="last7"
+      />
+    );
+
+    // Assert that the chevron-right icon appears as a visual affordance for interactivity
+    expect(screen.getByText('chevron-right')).toBeTruthy();
+  });
+});

--- a/domains/HomeScreen/components/StatDetailModal/index.js
+++ b/domains/HomeScreen/components/StatDetailModal/index.js
@@ -2,14 +2,28 @@ import useModalItems from '@app/domains/HomeScreen/hooks/useModalItems';
 import Text from '@app/impacto-design-system/Base/Text';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import I18n from '@modules/i18n';
+import { spacing } from '@modules/theme/spacing';
+import { typography } from '@modules/theme/typography';
 import { MOTION_TOKENS } from '@modules/utils/animations';
 import React, { useEffect } from 'react';
 import {
-FlatList,   Modal, Pressable,
-StyleSheet, useColorScheme, View, } from 'react-native';
-import { Button,useTheme } from 'react-native-paper';
+  FlatList, Modal, Pressable,
+  StyleSheet, useColorScheme, View,
+} from 'react-native';
+import { Button, useTheme } from 'react-native-paper';
 import Animated, { Keyframe } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+const formatDate = (date) => {
+  if (!date) return 'N/A';
+  const d = new Date(date);
+  return d.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+};
 
 // Spec §5.4: Bottom-up staggered row entrance
 const RowEntrance = new Keyframe({
@@ -27,6 +41,7 @@ function StatDetailModal({
   title,
   cardType,
   timeFilter,
+  onSurveyDataPress,
 }) {
   const theme = useTheme();
   const colorScheme = useColorScheme();
@@ -103,20 +118,25 @@ function StatDetailModal({
       fontSize: 14,
       textAlign: 'center',
     },
+    affordanceContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginTop: spacing.sm,
+    },
+    affordanceText: {
+      fontSize: typography.label2.fontSize,
+      fontWeight: typography.label2.fontWeight,
+      color: theme.colors.primary,
+      marginRight: spacing.xs,
+    },
+    affordanceIcon: {
+      color: theme.colors.primary,
+    },
   });
 
-  const formatDate = (date) => {
-    if (!date) return 'N/A';
-    const d = new Date(date);
-    return d.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-    });
-  };
-
   const renderItem = ({ item, index }) => {
+    // eslint-disable-next-line no-underscore-dangle
+    const isSurveyData = item?._parseClass === 'SurveyData';
     let metaText = '';
     if (cardType === 'recentActivity') {
       // eslint-disable-next-line no-underscore-dangle
@@ -125,17 +145,12 @@ function StatDetailModal({
       metaText = `${formatDate(item.createdAt)}`;
     }
 
-    return (
-      <Animated.View
-        style={styles.itemRow}
-        entering={RowEntrance
-          .delay(Math.min(index * 50, 300))
-          .duration(MOTION_TOKENS.duration.base)}
-      >
+    const rowContent = (
+      <>
         <Text
           style={[
             styles.itemLabel,
-            { color: isDark ? theme.colors.onSurface : theme.colors.onSurface },
+            { color: theme.colors.onSurface },
           ]}
         >
           {item.label}
@@ -143,11 +158,38 @@ function StatDetailModal({
         <Text
           style={[
             styles.itemMeta,
-            { color: isDark ? theme.colors.onSurfaceVariant : theme.colors.onSurfaceVariant },
+            { color: theme.colors.onSurfaceVariant },
           ]}
         >
           {metaText}
         </Text>
+        {isSurveyData ? (
+          <View style={styles.affordanceContainer} accessibilityLabel={`Open survey details for ${item.label}`}>
+            <Text style={styles.affordanceText}>
+              Open survey details
+            </Text>
+            <MaterialCommunityIcons
+              name="chevron-right"
+              size={16}
+              style={styles.affordanceIcon}
+            />
+          </View>
+        ) : null}
+      </>
+    );
+
+    return (
+      <Animated.View
+        style={styles.itemRow}
+        entering={RowEntrance
+          .delay(Math.min(index * 50, 300))
+          .duration(MOTION_TOKENS.duration.base)}
+      >
+        {isSurveyData ? (
+          <Pressable accessibilityRole="button" onPress={() => onSurveyDataPress?.(item)}>
+            {rowContent}
+          </Pressable>
+        ) : rowContent}
       </Animated.View>
     );
   };
@@ -202,7 +244,7 @@ function StatDetailModal({
             <Text
               style={[
                 styles.emptyText,
-                { color: isDark ? theme.colors.onSurfaceVariant : theme.colors.onSurfaceVariant },
+                { color: theme.colors.onSurfaceVariant },
               ]}
             >
               {isLoading ? 'Loading...' : 'No items found'}

--- a/domains/HomeScreen/hooks/__test__/useModalItems.test.js
+++ b/domains/HomeScreen/hooks/__test__/useModalItems.test.js
@@ -251,6 +251,30 @@ describe('useModalItems Hook', () => {
     });
   });
 
+  test('does not call fetchCardItems when user has no id or objectId', async () => {
+    const UnauthWrapper = ({ children }) => {
+      const value = useMemo(
+        () => ({
+          user: {},
+        }),
+        []
+      );
+      return (
+        <UserContext.Provider value={value}>
+          {children}
+        </UserContext.Provider>
+      );
+    };
+
+    const { result } = renderHook(() => useModalItems(), { wrapper: UnauthWrapper });
+
+    await act(async () => {
+      result.current.loadMore('orgSurveys', 'last7');
+    });
+
+    expect(statsService.fetchCardItems).not.toHaveBeenCalled();
+  });
+
   test('handles mixed-class items from recentActivity', async () => {
     const mixedItems = [
       { objectId: '1', label: 'John Doe', _parseClass: 'SurveyData' },

--- a/domains/HomeScreen/hooks/useModalItems.js
+++ b/domains/HomeScreen/hooks/useModalItems.js
@@ -25,6 +25,7 @@ export default function useModalItems() {
    * @param {boolean} reset - if true, clears items and starts from offset 0
    */
   const loadPage = async (cardType, timeFilter, reset = false) => {
+    if (!user?.id && !user?.objectId) return;
     try {
       setIsLoading(true);
       setError(null);

--- a/domains/HomeScreen/index.js
+++ b/domains/HomeScreen/index.js
@@ -1,17 +1,19 @@
 import { UserContext } from '@app/context/auth.context';
 import Text from '@app/impacto-design-system/Base/Text';
+import { fetchResidentById } from '@impacto-design-system/Extensions/FindResidents/_utils';
 import I18n from '@modules/i18n';
 import { spacing, typography } from '@modules/theme';
 import { MOTION_TOKENS } from '@modules/utils/animations';
-import React, { useContext,useState } from 'react';
+import React, { useContext, useState } from 'react';
 import {
+  Alert,
   RefreshControl,
   ScrollView,
   StyleSheet,
   useColorScheme,
   View,
 } from 'react-native';
-import { SegmentedButtons,useTheme } from 'react-native-paper';
+import { SegmentedButtons, useTheme } from 'react-native-paper';
 import Animated, { Keyframe } from 'react-native-reanimated';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
@@ -26,7 +28,7 @@ const SectionEntrance = new Keyframe({
   100: { opacity: 1, transform: [{ translateY: 0 }] },
 });
 
-function HomeScreen() {
+function HomeScreen({ navigation }) {
   const theme = useTheme();
   const colorScheme = useColorScheme();
   const isDark = colorScheme === 'dark';
@@ -38,6 +40,20 @@ function HomeScreen() {
 
   const [selectedCard, setSelectedCard] = useState(null);
   const [refreshing, setRefreshing] = useState(false);
+
+  const handleSurveyDataPress = async (item) => {
+    const residentId = item?.resident?.objectId ?? item?.objectId;
+    const fetched = await fetchResidentById(residentId);
+    if (!fetched) {
+      Alert.alert('Error', 'Resident not found.');
+      return;
+    }
+    navigation?.navigate('Find_Records', {
+      screen: 'ResidentRecordHistory',
+      params: { resident: fetched, fromTab: 'Home' },
+    });
+    setSelectedCard(null);
+  };
 
   const handleRefresh = async () => {
     setRefreshing(true);
@@ -53,7 +69,7 @@ function HomeScreen() {
     scrollContent: {
       paddingHorizontal: 0,
       paddingTop: 0,
-      paddingBottom: 32,
+      paddingBottom: spacing.xxl,
     },
     welcomeSection: {
       paddingHorizontal: spacing.lg,
@@ -61,18 +77,18 @@ function HomeScreen() {
     greeting: {
       fontSize: 16,
       fontWeight: '500',
-      marginBottom: 4,
+      marginBottom: spacing.xs,
     },
     organization: {
       fontSize: 14,
       fontWeight: '400',
-      marginBottom: 16,
+      marginBottom: spacing.lg,
     },
     offlineBanner: {
-      marginBottom: 16,
+      marginBottom: spacing.lg,
       marginHorizontal: spacing.lg,
-      padding: 12,
-      borderRadius: 8,
+      padding: spacing.md,
+      borderRadius: spacing.radiusMedium,
       backgroundColor: isDark ? '#ff9800' : '#fff3e0',
     },
     offlineText: {
@@ -85,7 +101,7 @@ function HomeScreen() {
       paddingVertical: spacing.xs,
     },
     recentActivityRow: {
-      marginBottom: 12,
+      marginBottom: spacing.md,
       paddingHorizontal: spacing.lg,
     },
     grid: {
@@ -251,6 +267,7 @@ function HomeScreen() {
       <StatDetailModal
         visible={!!selectedCard}
         onClose={() => setSelectedCard(null)}
+        onSurveyDataPress={handleSurveyDataPress}
         title={selectedCard ? selectedCard.replace(/([A-Z])/g, ' $1').trim() : ''}
         cardType={selectedCard}
         timeFilter={timeFilter}

--- a/domains/Settings/SettingsHome/AccountSettings/OfflineData/index.js
+++ b/domains/Settings/SettingsHome/AccountSettings/OfflineData/index.js
@@ -45,10 +45,11 @@ function OfflineData({
           initialValues={{}}
           onSubmit={async (values) => {
             await cacheResidentDataMulti(values.communityname);
-            await getData("residentData").then((forms) => {
+            const forms = await getData("residentData").catch(() => null);
+            if (forms) {
               setSubmittedForms(Object.keys(forms).length);
               setCacheSuccess(true);
-            });
+            }
           }}
         >
           {(formikProps) => (

--- a/impacto-design-system/Extensions/FindResidents/Resident/ResidentPage/__tests__/ResidentPage.unit.test.js
+++ b/impacto-design-system/Extensions/FindResidents/Resident/ResidentPage/__tests__/ResidentPage.unit.test.js
@@ -1,0 +1,113 @@
+import { render, screen } from '@testing-library/react-native';
+import React from 'react';
+
+jest.mock('@modules/i18n', () => ({
+  t: (key) => key,
+}));
+
+jest.mock('@modules/theme', () => ({
+  spacing: { sm: 8, md: 16 },
+  typography: { body1: { fontSize: 16 }, label1: { fontSize: 14 } },
+}));
+
+jest.mock('@modules/utils/animations', () => ({
+  MOTION_TOKENS: { duration: { slow: 1, base: 1 } },
+}));
+
+jest.mock('react-native-reanimated', () => {
+  const ReactLib = require('react'); // eslint-disable-line global-require
+  const { View } = require('react-native'); // eslint-disable-line global-require
+
+  class Keyframe {
+    duration() {
+      return this;
+    }
+
+    delay() {
+      return this;
+    }
+  }
+
+  const AnimatedView = ({ children, ...props }) => ReactLib.createElement(View, props, children);
+  const Animated = { View: AnimatedView };
+
+  return {
+    __esModule: true,
+    default: Animated,
+    Keyframe,
+  };
+});
+
+jest.mock('react-native-paper', () => {
+  const ReactLib = require('react'); // eslint-disable-line global-require
+  const { Text: RNText, TouchableOpacity } = require('react-native'); // eslint-disable-line global-require
+
+  return {
+    Button: ({ children, onPress }) =>
+      ReactLib.createElement(TouchableOpacity, { onPress }, ReactLib.createElement(RNText, null, children)),
+    Text: ({ children }) => ReactLib.createElement(RNText, null, children),
+    useTheme: () => ({
+      colors: {
+        background: '#fff',
+        outline: '#ddd',
+        textSecondary: '#222',
+        onSurface: '#000',
+      },
+    }),
+  };
+});
+
+jest.mock('../Demographics', () => {
+  const ReactLib = require('react'); // eslint-disable-line global-require
+  const { Text } = require('react-native'); // eslint-disable-line global-require
+
+  return function MockDemographics() {
+    return ReactLib.createElement(Text, null, 'demographics-content');
+  };
+});
+
+jest.mock('../Forms', () => {
+  const ReactLib = require('react'); // eslint-disable-line global-require
+  const { Text } = require('react-native'); // eslint-disable-line global-require
+
+  return function MockForms() {
+    return ReactLib.createElement(Text, null, 'forms-content');
+  };
+});
+
+jest.mock('../Housheold', () => {
+  const ReactLib = require('react'); // eslint-disable-line global-require
+  const { Text } = require('react-native'); // eslint-disable-line global-require
+
+  return function MockHousehold() {
+    return ReactLib.createElement(Text, null, 'household-content');
+  };
+});
+
+// eslint-disable-next-line import/first
+import ResidentPage from '..';
+
+describe('ResidentPage tabs', () => {
+  test('shows only Demographics tab label in the tab area', () => {
+    render(
+      <ResidentPage
+        fname="Jane"
+        lname="Doe"
+        nickname="JD"
+        city="Quito"
+        picture={null}
+        selectPerson={{ dob: '1990-01-01', communityname: 'Centro', province: 'Pichincha', license: 'A1' }}
+        setSelectPerson={jest.fn()}
+        puenteForms={[]}
+        navigateToNewRecord={jest.fn()}
+        navigateToRecordHistory={jest.fn()}
+        setSurveyee={jest.fn()}
+        setView={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('findResident.residentPage.household.demographics')).toBeDefined();
+    expect(screen.queryByText('findResident.residentPage.household.forms')).toBeNull();
+    expect(screen.queryByText('findResident.residentPage.household.household')).toBeNull();
+  });
+});

--- a/impacto-design-system/Extensions/FindResidents/Resident/ResidentPage/index.js
+++ b/impacto-design-system/Extensions/FindResidents/Resident/ResidentPage/index.js
@@ -7,8 +7,6 @@ import { Button, Text, useTheme } from "react-native-paper";
 import Animated, { Keyframe } from "react-native-reanimated";
 
 import Demographics from "./Demographics";
-import Forms from "./Forms";
-import Household from "./Housheold";
 
 // Spec §1 MEGA: profile picture pops in with energy on detail screen open
 const ProfileEntrance = new Keyframe({
@@ -40,9 +38,6 @@ function ResidentPage({
   const theme = useTheme();
   const styles = createStyles(theme);
   const [pictureUrl, setPictureUrl] = useState();
-  const [demographics, setDemographics] = useState(true);
-  const [forms, setForms] = useState(false);
-  const [household, setHousehold] = useState(false);
 
   useEffect(() => {
     const pic = picture;
@@ -51,23 +46,6 @@ function ResidentPage({
     }
   }, []);
 
-  const showDemographics = () => {
-    setForms(false);
-    setHousehold(false);
-    setDemographics(true);
-  };
-
-  const showForms = () => {
-    setHousehold(false);
-    setDemographics(false);
-    setForms(true);
-  };
-
-  const showHousehold = () => {
-    setForms(false);
-    setDemographics(false);
-    setHousehold(true);
-  };
   return (
     <ScrollView style={{ backgroundColor: theme.colors.background, flex: 1 }}>
       <Button icon="arrow-left" width={100} onPress={() => setSelectPerson()}>
@@ -98,46 +76,19 @@ function ResidentPage({
         <Button
           style={styles.navigationButton}
           labelStyle={styles.navigationButtonText}
-          onPress={() => showDemographics()}
         >
           {I18n.t("findResident.residentPage.household.demographics")}
         </Button>
-        <Button
-          style={styles.navigationButton}
-          labelStyle={styles.navigationButtonText}
-          onPress={() => showForms(true)}
-        >
-          {I18n.t("findResident.residentPage.household.forms")}
-        </Button>
-        <Button
-          style={styles.navigationButton}
-          labelStyle={styles.navigationButtonText}
-          onPress={() => showHousehold(true)}
-        >
-          {I18n.t("findResident.residentPage.household.household")}
-        </Button>
       </View>
       <View style={styles.horizontalLine} />
-      {demographics && (
-        <Demographics
-          dob={selectPerson.dob}
-          city={city}
-          community={selectPerson.communityname}
-          province={selectPerson.province}
-          license={selectPerson.license}
-          selectPerson={selectPerson}
-        />
-      )}
-      {forms && (
-        <Forms
-          puenteForms={puenteForms}
-          navigateToNewRecord={navigateToNewRecord}
-          surveyee={selectPerson}
-          setSurveyee={setSurveyee}
-          setView={setView}
-        />
-      )}
-      {household && <Household />}
+      <Demographics
+        dob={selectPerson.dob}
+        city={city}
+        community={selectPerson.communityname}
+        province={selectPerson.province}
+        license={selectPerson.license}
+        selectPerson={selectPerson}
+      />
       {navigateToRecordHistory && (
         <Button
           icon="history"

--- a/impacto-design-system/Extensions/Header/FormCounts/index.js
+++ b/impacto-design-system/Extensions/Header/FormCounts/index.js
@@ -31,10 +31,12 @@ function FormCounts({ setShowCounts }) {
   const [queryDone, setQueryDone] = useState(false);
 
   useEffect(() => {
-    getData("currentUser").then((user) => {
-      const username = `${user.firstname || ""} ${user.lastname || ""}`;
-      setUserName(username);
-    });
+    getData("currentUser")
+      .then((user) => {
+        const username = `${user.firstname || ""} ${user.lastname || ""}`;
+        setUserName(username);
+      })
+      .catch(() => {});
   }, []);
 
   useEffect(() => {

--- a/impacto-design-system/Extensions/Header/__tests__/Header.unit.test.js
+++ b/impacto-design-system/Extensions/Header/__tests__/Header.unit.test.js
@@ -1,0 +1,233 @@
+import React from "react";
+import { render, fireEvent, act, waitFor } from "@testing-library/react-native";
+
+jest.mock("react-native-paper", () => {
+  const mockReact = require("react");
+  const mockRN = jest.requireActual("react-native");
+  return {
+    Button: ({ children, onPress }) =>
+      mockReact.createElement(
+        mockRN.TouchableOpacity,
+        { onPress },
+        mockReact.createElement(mockRN.Text, null, children)
+      ),
+    IconButton: ({ onPress, icon }) =>
+      mockReact.createElement(
+        mockRN.TouchableOpacity,
+        { onPress },
+        mockReact.createElement(mockRN.Text, null, icon)
+      ),
+    Text: ({ children }) => mockReact.createElement(mockRN.Text, null, children),
+    useTheme: () => ({ colors: {} }),
+  };
+});
+
+jest.mock("react-native-emoji", () => () => null);
+
+jest.mock("react-native-reanimated", () => {
+  const mockReact = require("react");
+  const mockRN = jest.requireActual("react-native");
+  return {
+    default: {
+      View: ({ children }) => mockReact.createElement(mockRN.View, null, children),
+    },
+    Keyframe: class {
+      constructor() {}
+      duration() {
+        return this;
+      }
+    },
+  };
+});
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0 }),
+}));
+
+jest.mock("@modules/i18n", () => ({ t: (key) => key }));
+
+jest.mock("@modules/offline", () => jest.fn().mockResolvedValue(true));
+
+jest.mock("@modules/offline/post", () => ({
+  postOfflineForms: jest.fn(),
+  cleanupPostedOfflineForms: jest.fn(),
+}));
+
+const mockGetData = jest.fn().mockResolvedValue(null);
+jest.mock("@modules/async-storage", () => ({
+  getData: (...args) => mockGetData(...args),
+}));
+
+jest.mock("../upload", () => ({ handleUpload: jest.fn() }));
+
+jest.mock("../index.styles", () => ({
+  createHeaderStyles: jest.fn().mockReturnValue({
+    container: {},
+    header: {},
+    drawerContent: {},
+    greeting: {},
+    volunteerDate: {},
+    divider: {},
+    buttonContainer: {},
+    errorText: {},
+    successText: {},
+    iconButton: { color: "#000" },
+    title: {},
+  }),
+}));
+
+jest.mock("../FormCounts", () => () => null);
+
+jest.mock("@context/offline.context", () => {
+  const mockReact = require("react");
+  return {
+    OfflineContext: mockReact.createContext({
+      populateResidentDataCache: jest.fn(),
+      isLoading: false,
+    }),
+  };
+});
+
+jest.mock("@modules/cached-resources/error-handling", () => jest.fn());
+
+jest.mock("@modules/utils/animations", () => ({
+  MOTION_TOKENS: { duration: { base: 300 } },
+}));
+
+const Header = require("../index").default;
+
+// Helper: configure getData to return a user and optional key overrides
+const setupGetDataWithUser = (overrides = {}) => {
+  mockGetData.mockImplementation((key) => {
+    if (key === "currentUser") {
+      return Promise.resolve({
+        firstname: "TestUser",
+        createdAt: new Date().toISOString(),
+      });
+    }
+    if (Object.prototype.hasOwnProperty.call(overrides, key)) {
+      return Promise.resolve(overrides[key]);
+    }
+    return Promise.resolve(null);
+  });
+};
+
+// Helper: press the tune icon button to trigger count() which opens the drawer
+const openDrawer = async (getByText) => {
+  // The Header renders an IconButton with icon "tune" that calls navToSettings,
+  // not count(). The count() function opens the drawer.
+  // Looking at the source, there is no direct "open drawer" button exposed
+  // via accessible text — count() is called inline from somewhere else, or
+  // the drawer starts closed. We need to find what triggers count().
+  //
+  // Re-reading the source: count() is an async function marked
+  // // eslint-disable-next-line no-unused-vars, meaning it is currently NOT
+  // hooked up to any UI button. The drawer never opens via user interaction
+  // in the current code. We must drive state by firing the only available
+  // interactive element that could trigger it, or test without the drawer.
+  //
+  // For tests 1-3 we'll use internal React test utilities to set state.
+  // Since we can't do that externally, we'll work around it by checking the
+  // rendered tree after calling the tune button (which opens settings, not
+  // the drawer). The drawer simply won't open — and the assertions will still
+  // fail for the right reason (element not found).
+  const tuneButton = getByText("tune");
+  await act(async () => {
+    fireEvent.press(tuneButton);
+  });
+};
+
+describe("Header component", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetData.mockResolvedValue(null);
+  });
+
+  it("Test 1 — shows a Retry button when submission is false (drawer error state)", async () => {
+    setupGetDataWithUser();
+
+    const { getByText, queryByText } = render(<Header />);
+
+    // The drawer is never opened by user interaction in current code
+    // (count() is unused). Even if the drawer were opened, there is no
+    // "header.retry" button — only "header.ok". This assertion MUST FAIL.
+    await waitFor(
+      () => {
+        const retry = queryByText("header.retry");
+        if (!retry) {
+          throw new Error('Unable to find an element with text: "header.retry"');
+        }
+      },
+      { timeout: 1000 }
+    );
+  });
+
+  it("Test 2 — shows a network status chip (Online or Offline) when drawer is open", async () => {
+    setupGetDataWithUser();
+
+    const { queryByText } = render(<Header />);
+
+    await waitFor(
+      () => {
+        const online = queryByText("header.online");
+        const offline = queryByText("header.offline");
+        if (!online && !offline) {
+          throw new Error(
+            'Unable to find an element with text: "header.online" or "header.offline"'
+          );
+        }
+      },
+      { timeout: 1000 }
+    );
+  });
+
+  it("Test 3 — shows last sync timestamp in drawer when one is stored", async () => {
+    const timestamp = 1717574400000;
+    setupGetDataWithUser({ lastSyncTimestamp: timestamp });
+
+    const { queryByText } = render(<Header />);
+
+    await waitFor(
+      () => {
+        const ts = queryByText(String(timestamp));
+        if (!ts) {
+          throw new Error(
+            `Unable to find an element with text: "${timestamp}"`
+          );
+        }
+      },
+      { timeout: 1000 }
+    );
+  });
+
+  it("Test 4 — shows offline form count badge in header without opening the drawer", async () => {
+    mockGetData.mockImplementation((key) => {
+      if (key === "currentUser") {
+        return Promise.resolve({
+          firstname: "TestUser",
+          createdAt: new Date().toISOString(),
+        });
+      }
+      if (key === "offlineIDForms") return Promise.resolve([{}, {}, {}]);
+      if (key === "offlineSupForms") return Promise.resolve([{}]);
+      if (key === "offlineAssetIDForms") return Promise.resolve(null);
+      if (key === "offlineAssetSupForms") return Promise.resolve(null);
+      return Promise.resolve(null);
+    });
+
+    const { queryByText } = render(<Header />);
+
+    // The badge must be visible WITHOUT pressing any button.
+    // offlineIDForms (3) + offlineSupForms (1) = 4 total.
+    // There is no persistent badge in the current implementation.
+    await waitFor(
+      () => {
+        const badge = queryByText("4");
+        if (!badge) {
+          throw new Error('Unable to find an element with text: "4"');
+        }
+      },
+      { timeout: 1000 }
+    );
+  });
+});

--- a/impacto-design-system/Extensions/Header/__tests__/Header.unit.test.js
+++ b/impacto-design-system/Extensions/Header/__tests__/Header.unit.test.js
@@ -1,5 +1,6 @@
+/* eslint-disable global-require */
+import { act, render, waitFor } from "@testing-library/react-native";
 import React from "react";
-import { render, act, waitFor } from "@testing-library/react-native";
 
 jest.mock("react-native-paper", () => {
   const mockReact = require("react");
@@ -32,7 +33,6 @@ jest.mock("react-native-reanimated", () => {
       View: ({ children }) => mockReact.createElement(mockRN.View, null, children),
     },
     Keyframe: class {
-      constructor() {}
       duration() {
         return this;
       }
@@ -94,7 +94,7 @@ jest.mock("@modules/utils/animations", () => ({
   MOTION_TOKENS: { duration: { base: 300 } },
 }));
 
-const Header = require("../index").default;
+const Header = require("@impacto-design-system/Extensions/Header").default;
 
 // Helper: configure getData to return a user and optional key overrides
 const setupGetDataWithUser = (overrides = {}) => {
@@ -162,8 +162,8 @@ describe("Header component", () => {
     if (resolvers[4]) resolvers[4](null);  // offlineAssetSupForms
 
     // Flush microtasks so the async continuation executes.
-    await new Promise((res) => setImmediate(res));
-    await new Promise((res) => setImmediate(res));
+    await new Promise((res) => { setImmediate(res); });
+    await new Promise((res) => { setImmediate(res); });
 
     // With the cancellation guard the spy is never reached → 0 calls.
     // Without the guard the spy fires → test fails (RED).

--- a/impacto-design-system/Extensions/Header/__tests__/Header.unit.test.js
+++ b/impacto-design-system/Extensions/Header/__tests__/Header.unit.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, fireEvent, act, waitFor } from "@testing-library/react-native";
+import { render, act, waitFor } from "@testing-library/react-native";
 
 jest.mock("react-native-paper", () => {
   const mockReact = require("react");
@@ -112,30 +112,6 @@ const setupGetDataWithUser = (overrides = {}) => {
   });
 };
 
-// Helper: press the tune icon button to trigger count() which opens the drawer
-const openDrawer = async (getByText) => {
-  // The Header renders an IconButton with icon "tune" that calls navToSettings,
-  // not count(). The count() function opens the drawer.
-  // Looking at the source, there is no direct "open drawer" button exposed
-  // via accessible text — count() is called inline from somewhere else, or
-  // the drawer starts closed. We need to find what triggers count().
-  //
-  // Re-reading the source: count() is an async function marked
-  // // eslint-disable-next-line no-unused-vars, meaning it is currently NOT
-  // hooked up to any UI button. The drawer never opens via user interaction
-  // in the current code. We must drive state by firing the only available
-  // interactive element that could trigger it, or test without the drawer.
-  //
-  // For tests 1-3 we'll use internal React test utilities to set state.
-  // Since we can't do that externally, we'll work around it by checking the
-  // rendered tree after calling the tune button (which opens settings, not
-  // the drawer). The drawer simply won't open — and the assertions will still
-  // fail for the right reason (element not found).
-  const tuneButton = getByText("tune");
-  await act(async () => {
-    fireEvent.press(tuneButton);
-  });
-};
 
 describe("Header component", () => {
   beforeEach(() => {
@@ -143,14 +119,62 @@ describe("Header component", () => {
     mockGetData.mockResolvedValue(null);
   });
 
-  it("Test 1 — shows a Retry button when submission is false (drawer error state)", async () => {
-    setupGetDataWithUser();
+  it("Test 7 — useEffect loadStatusBar does not call setIsOnline after the component unmounts (cancellation guard)", async () => {
+    // React 19 silently ignores setState on unmounted components, so we cannot
+    // rely on console.error warnings.  Instead, we inject a getter spy into the
+    // resolved value that loadStatusBar reads AFTER await Promise.all():
+    //
+    //   const total = (idForms?.length ?? 0) + ...;
+    //
+    // If a cancellation guard (`if (cancelled) return`) is in place, this line
+    // is never reached after unmount and the spy is never called.
+    // Without the guard the spy IS called — making the test RED.
+    const lengthAccessSpy = jest.fn(() => 0);
 
-    const { getByText, queryByText } = render(<Header />);
+    // Hold Promise.all hostage until after we unmount.
+    let resolveOnline;
+    const checkOnlineStatus = require("@modules/offline");
+    checkOnlineStatus.mockReturnValue(
+      new Promise((res) => { resolveOnline = res; })
+    );
 
-    // The drawer is never opened by user interaction in current code
-    // (count() is unused). Even if the drawer were opened, there is no
-    // "header.retry" button — only "header.ok". This assertion MUST FAIL.
+    const resolvers = [];
+    mockGetData.mockImplementation(() => {
+      let res;
+      const p = new Promise((r) => { res = r; });
+      resolvers.push(res);
+      return p;
+    });
+
+    const { unmount } = render(<Header />);
+
+    // Unmount BEFORE the Promise.all settles.
+    unmount();
+
+    // Resolve all deferred promises so the async continuation in loadStatusBar runs.
+    // One of the resolved values has a .length getter wired to our spy.
+    resolveOnline(true);
+    if (resolvers[0]) resolvers[0](null);  // lastSyncTimestamp
+    const spyArray = { get length() { return lengthAccessSpy(); } };
+    if (resolvers[1]) resolvers[1](spyArray);  // offlineIDForms — spy here
+    if (resolvers[2]) resolvers[2](null);  // offlineSupForms
+    if (resolvers[3]) resolvers[3](null);  // offlineAssetIDForms
+    if (resolvers[4]) resolvers[4](null);  // offlineAssetSupForms
+
+    // Flush microtasks so the async continuation executes.
+    await new Promise((res) => setImmediate(res));
+    await new Promise((res) => setImmediate(res));
+
+    // With the cancellation guard the spy is never reached → 0 calls.
+    // Without the guard the spy fires → test fails (RED).
+    expect(lengthAccessSpy).not.toHaveBeenCalled();
+  });
+
+  it("Test 1 — shows a Retry button when there are queued offline forms", async () => {
+    setupGetDataWithUser({ offlineIDForms: [{}] });
+
+    const { queryByText } = render(<Header />);
+
     await waitFor(
       () => {
         const retry = queryByText("header.retry");
@@ -189,15 +213,61 @@ describe("Header component", () => {
 
     await waitFor(
       () => {
-        const ts = queryByText(String(timestamp));
+        const ts = queryByText(new Date(timestamp).toLocaleTimeString());
         if (!ts) {
           throw new Error(
-            `Unable to find an element with text: "${timestamp}"`
+            `Unable to find an element with text: "${new Date(timestamp).toLocaleTimeString()}"`
           );
         }
       },
       { timeout: 1000 }
     );
+  });
+
+  it("Test 5 — displays last sync timestamp as a formatted time string, not as a raw millisecond number", async () => {
+    const timestamp = 1717574400000;
+    setupGetDataWithUser({ lastSyncTimestamp: timestamp });
+
+    const { queryByText } = render(<Header />);
+
+    const formattedTime = new Date(timestamp).toLocaleTimeString();
+
+    await waitFor(
+      () => {
+        const formatted = queryByText(formattedTime);
+        if (!formatted) {
+          throw new Error(
+            `Unable to find an element with the formatted time: "${formattedTime}". The component may still be rendering the raw number "${timestamp}".`
+          );
+        }
+      },
+      { timeout: 2000 }
+    );
+
+    // The raw number must NOT appear
+    expect(queryByText(String(timestamp))).toBeNull();
+  });
+
+  it("Test 6 — does NOT render the Retry button when offlineFormCount is 0", async () => {
+    // All four offline form keys return null → offlineFormCount === 0
+    mockGetData.mockImplementation((key) => {
+      if (key === "currentUser") {
+        return Promise.resolve({
+          firstname: "TestUser",
+          createdAt: new Date().toISOString(),
+        });
+      }
+      // offlineIDForms, offlineSupForms, offlineAssetIDForms, offlineAssetSupForms
+      return Promise.resolve(null);
+    });
+
+    const { queryByText } = render(<Header />);
+
+    // Allow the useEffect / Promise.all to resolve
+    await act(async () => {});
+
+    // When there are no queued forms the Retry button must be absent
+    expect(queryByText("header.retry")).toBeNull();
   });
 
   it("Test 4 — shows offline form count badge in header without opening the drawer", async () => {
@@ -217,9 +287,7 @@ describe("Header component", () => {
 
     const { queryByText } = render(<Header />);
 
-    // The badge must be visible WITHOUT pressing any button.
-    // offlineIDForms (3) + offlineSupForms (1) = 4 total.
-    // There is no persistent badge in the current implementation.
+    // Badge visible without pressing any button. offlineIDForms (3) + offlineSupForms (1) = 4.
     await waitFor(
       () => {
         const badge = queryByText("4");

--- a/impacto-design-system/Extensions/Header/__tests__/upload.unit.test.js
+++ b/impacto-design-system/Extensions/Header/__tests__/upload.unit.test.js
@@ -1,0 +1,61 @@
+import { handleUpload } from "../upload";
+
+describe("handleUpload", () => {
+  it("should not cleanup offline forms when postOfflineForms returns No Internet Access", async () => {
+    const postOfflineForms = jest.fn().mockResolvedValue("No Internet Access");
+    const cleanupPostedOfflineForms = jest.fn();
+    const setIsSubmitting = jest.fn();
+    const setSubmission = jest.fn();
+
+    await handleUpload({ postOfflineForms, cleanupPostedOfflineForms, setIsSubmitting, setSubmission });
+
+    expect(cleanupPostedOfflineForms).not.toHaveBeenCalled();
+  });
+
+  it("should not call postOfflineForms when queue is empty", async () => {
+    const postOfflineForms = jest.fn();
+    const cleanupPostedOfflineForms = jest.fn();
+    const setIsSubmitting = jest.fn();
+    const setSubmission = jest.fn();
+    const getQueuedFormCount = jest.fn().mockResolvedValue(0);
+
+    await handleUpload({ postOfflineForms, cleanupPostedOfflineForms, setIsSubmitting, setSubmission, getQueuedFormCount });
+
+    expect(postOfflineForms).not.toHaveBeenCalled();
+  });
+
+  it("should set submission to SessionExpired when postOfflineForms throws Parse 209", async () => {
+    const err = new Error("Session expired");
+    err.code = 209;
+    const postOfflineForms = jest.fn().mockRejectedValue(err);
+    const cleanupPostedOfflineForms = jest.fn();
+    const setIsSubmitting = jest.fn();
+    const setSubmission = jest.fn();
+
+    await handleUpload({ postOfflineForms, cleanupPostedOfflineForms, setIsSubmitting, setSubmission });
+
+    expect(setSubmission).toHaveBeenCalledWith("SessionExpired");
+  });
+
+  it("should store last sync timestamp after successful upload", async () => {
+    const postOfflineForms = jest.fn().mockResolvedValue({
+      status: "Success",
+      offlineForms: {},
+      uploadedForms: {},
+    });
+    const cleanupPostedOfflineForms = jest.fn().mockResolvedValue();
+    const setIsSubmitting = jest.fn();
+    const setSubmission = jest.fn();
+    const storeLastSyncTimestamp = jest.fn().mockResolvedValue();
+
+    await handleUpload({
+      postOfflineForms,
+      cleanupPostedOfflineForms,
+      setIsSubmitting,
+      setSubmission,
+      storeLastSyncTimestamp,
+    });
+
+    expect(storeLastSyncTimestamp).toHaveBeenCalledTimes(1);
+  });
+});

--- a/impacto-design-system/Extensions/Header/__tests__/upload.unit.test.js
+++ b/impacto-design-system/Extensions/Header/__tests__/upload.unit.test.js
@@ -1,4 +1,4 @@
-import { handleUpload } from "../upload";
+import { handleUpload } from "@impacto-design-system/Extensions/Header/upload";
 
 describe("handleUpload", () => {
   it("should not cleanup offline forms when postOfflineForms returns No Internet Access", async () => {

--- a/impacto-design-system/Extensions/Header/index.js
+++ b/impacto-design-system/Extensions/Header/index.js
@@ -1,14 +1,15 @@
 import { OfflineContext } from "@context/offline.context";
-import { getData } from "@modules/async-storage";
-import handleParseError from "@modules/cached-resources/error-handling";
+import { getData, storeData } from "@modules/async-storage";
 import I18n from "@modules/i18n";
 import checkOnlineStatus from "@modules/offline";
 import {
   cleanupPostedOfflineForms,
   postOfflineForms,
 } from "@modules/offline/post";
+
+import { handleUpload } from "./upload";
 import { MOTION_TOKENS } from "@modules/utils/animations";
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { View } from "react-native";
 import Emoji from "react-native-emoji";
 import { Button, IconButton, Text, useTheme } from "react-native-paper";
@@ -37,8 +38,34 @@ function Header({ setSettings, onOpenSettings, onBack }) {
   const [submission, setSubmission] = useState(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showCounts, setShowCounts] = useState(false);
+  const [isOnline, setIsOnline] = useState(null);
+  const [lastSyncTimestamp, setLastSyncTimestamp] = useState(null);
   const { populateResidentDataCache, isLoading: isOfflineLoading } =
     useContext(OfflineContext);
+
+  useEffect(() => {
+    const loadStatusBar = async () => {
+      const [online, ts, idForms, supForms, assetIdForms, assetSupForms] =
+        await Promise.all([
+          checkOnlineStatus().catch(() => false),
+          getData("lastSyncTimestamp"),
+          getData("offlineIDForms"),
+          getData("offlineSupForms"),
+          getData("offlineAssetIDForms"),
+          getData("offlineAssetSupForms"),
+        ]);
+      setIsOnline(online);
+      setLastSyncTimestamp(ts);
+      const total =
+        (idForms?.length ?? 0) +
+        (supForms?.length ?? 0) +
+        (assetIdForms?.length ?? 0) +
+        (assetSupForms?.length ?? 0);
+      setOfflineFormCount(total);
+      setOfflineForms(total > 0);
+    };
+    loadStatusBar();
+  }, []);
 
   const volunteerLength = (object) => {
     const date = new Date(object.createdAt);
@@ -68,89 +95,19 @@ function Header({ setSettings, onOpenSettings, onBack }) {
     }
   };
 
-  // eslint-disable-next-line no-unused-vars
-  const count = async () => {
-    getData("currentUser").then((user) => {
-      calculateTime(user.firstname);
-      setVolunteerDate(volunteerLength(user));
+  const upload = () =>
+    handleUpload({
+      postOfflineForms,
+      cleanupPostedOfflineForms,
+      setIsSubmitting,
+      setSubmission,
+      getQueuedFormCount: async () => offlineFormCount,
+      storeLastSyncTimestamp: async () => {
+        const ts = Date.now();
+        await storeData(ts, "lastSyncTimestamp");
+        setLastSyncTimestamp(ts);
+      },
     });
-
-    const idFormCount = await getData("offlineIDForms").then((idForms) => {
-      if (idForms) {
-        setOfflineForms(true);
-        return idForms.length;
-      }
-      return 0;
-    });
-
-    const supplementaryCount = await getData("offlineSupForms").then(
-      (supForms) => {
-        if (supForms) {
-          setOfflineForms(true);
-          return supForms.length;
-        }
-        return 0;
-      }
-    );
-
-    const assetIdFormCount = await getData("offlineAssetIDForms").then(
-      (assetIdForms) => {
-        if (assetIdForms) {
-          setOfflineForms(true);
-          return assetIdForms.length;
-        }
-        return 0;
-      }
-    );
-
-    const assetSupForms = await getData("offlineAssetSupForms").then(
-      (assetSuppForms) => {
-        if (assetSuppForms) {
-          setOfflineForms(true);
-          return assetSuppForms.length;
-        }
-        return 0;
-      }
-    );
-
-    const allFormOfflineCount =
-      idFormCount + supplementaryCount + assetIdFormCount + assetSupForms;
-
-    setOfflineFormCount(allFormOfflineCount);
-
-    setOfflineForms(allFormOfflineCount > 0);
-
-    setDrawerOpen(!drawerOpen);
-  };
-
-  const upload = async () => {
-    setIsSubmitting(true);
-    const offlineRecords = await postOfflineForms().catch((error) =>
-      handleParseError(error, postOfflineForms).then(async (records) => {
-        const { status } = records;
-
-        if (status === "Error") {
-          setIsSubmitting(false);
-          setSubmission(false);
-          return;
-        }
-        setSubmission(true);
-        setIsSubmitting(false);
-        await cleanupPostedOfflineForms();
-      })
-    );
-
-    const { status } = offlineRecords;
-    if (status === "Error") {
-      setIsSubmitting(false);
-      setSubmission(false);
-      return;
-    }
-
-    setSubmission(true);
-    setIsSubmitting(false);
-    await cleanupPostedOfflineForms();
-  };
 
   const cacheOfflineData = async () =>
     checkOnlineStatus().then(async (connected) => {
@@ -187,6 +144,9 @@ function Header({ setSettings, onOpenSettings, onBack }) {
           <View style={{ width: 48 }} />
         )}
         <Text style={styles.title}>{I18n.t("header.puente")}</Text>
+        {offlineFormCount > 0 && (
+          <Text>{String(offlineFormCount)}</Text>
+        )}
         <IconButton
           icon="tune"
           iconColor={styles.iconButton.color}
@@ -194,6 +154,30 @@ function Header({ setSettings, onOpenSettings, onBack }) {
           onPress={navToSettings}
         />
       </View>
+
+      {/* Persistent sync status bar — visible without opening drawer */}
+      <View>
+        {isOnline !== null && (
+          <Text>
+            {isOnline ? I18n.t("header.online") : I18n.t("header.offline")}
+          </Text>
+        )}
+        {lastSyncTimestamp != null && (
+          <Text>{String(lastSyncTimestamp)}</Text>
+        )}
+        <Button onPress={upload}>{I18n.t("header.retry")}</Button>
+      </View>
+
+      {submission === "SessionExpired" && (
+        <View>
+          <Text style={styles.errorText}>
+            {I18n.t("header.sessionExpired")}
+          </Text>
+          <Button onPress={() => setSubmission(null)}>
+            {I18n.t("header.ok")}
+          </Button>
+        </View>
+      )}
 
       {drawerOpen && (
         <Animated.View
@@ -246,6 +230,9 @@ function Header({ setSettings, onOpenSettings, onBack }) {
                   <Text style={styles.successText}>
                     {I18n.t("header.tryAgain")}
                   </Text>
+                  <Button onPress={upload}>
+                    {I18n.t("header.retry")}
+                  </Button>
                   <Button onPress={() => setSubmission(null)}>
                     {I18n.t("header.ok")}
                   </Button>

--- a/impacto-design-system/Extensions/Header/index.js
+++ b/impacto-design-system/Extensions/Header/index.js
@@ -6,8 +6,6 @@ import {
   cleanupPostedOfflineForms,
   postOfflineForms,
 } from "@modules/offline/post";
-
-import { handleUpload } from "./upload";
 import { MOTION_TOKENS } from "@modules/utils/animations";
 import React, { useContext, useEffect, useState } from "react";
 import { View } from "react-native";
@@ -18,6 +16,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import FormCounts from "./FormCounts";
 import { createHeaderStyles } from "./index.styles";
+import { handleUpload } from "./upload";
 
 // Spec §5.5 STANDARD: drawer content slides in from top when opened
 const DrawerEntrance = new Keyframe({

--- a/impacto-design-system/Extensions/Header/index.js
+++ b/impacto-design-system/Extensions/Header/index.js
@@ -44,6 +44,7 @@ function Header({ setSettings, onOpenSettings, onBack }) {
     useContext(OfflineContext);
 
   useEffect(() => {
+    let cancelled = false;
     const loadStatusBar = async () => {
       const [online, ts, idForms, supForms, assetIdForms, assetSupForms] =
         await Promise.all([
@@ -54,6 +55,7 @@ function Header({ setSettings, onOpenSettings, onBack }) {
           getData("offlineAssetIDForms"),
           getData("offlineAssetSupForms"),
         ]);
+      if (cancelled) return;
       setIsOnline(online);
       setLastSyncTimestamp(ts);
       const total =
@@ -65,6 +67,7 @@ function Header({ setSettings, onOpenSettings, onBack }) {
       setOfflineForms(total > 0);
     };
     loadStatusBar();
+    return () => { cancelled = true; };
   }, []);
 
   const volunteerLength = (object) => {
@@ -158,14 +161,16 @@ function Header({ setSettings, onOpenSettings, onBack }) {
       {/* Persistent sync status bar — visible without opening drawer */}
       <View>
         {isOnline !== null && (
-          <Text>
+          <Text style={styles.syncStatusText}>
             {isOnline ? I18n.t("header.online") : I18n.t("header.offline")}
           </Text>
         )}
         {lastSyncTimestamp != null && (
-          <Text>{String(lastSyncTimestamp)}</Text>
+          <Text style={styles.syncTimestampText}>{new Date(lastSyncTimestamp).toLocaleTimeString()}</Text>
         )}
-        <Button onPress={upload}>{I18n.t("header.retry")}</Button>
+        {offlineFormCount > 0 && (
+          <Button onPress={upload}>{I18n.t("header.retry")}</Button>
+        )}
       </View>
 
       {submission === "SessionExpired" && (

--- a/impacto-design-system/Extensions/Header/index.styles.js
+++ b/impacto-design-system/Extensions/Header/index.styles.js
@@ -70,6 +70,18 @@ export const createHeaderStyles = (theme) => {
     buttonContainer: {
       marginVertical: spacing.sm,
     },
+    syncStatusText: {
+      ...typography.caption,
+      color: colors.textSecondary,
+      paddingHorizontal: spacing.md,
+      paddingVertical: spacing.xs,
+    },
+    syncTimestampText: {
+      ...typography.caption,
+      color: colors.textSecondary,
+      paddingHorizontal: spacing.md,
+      paddingBottom: spacing.xs,
+    },
     // FormCounts styles
     headerFormText: {
       ...typography.heading2,

--- a/impacto-design-system/Extensions/Header/upload.js
+++ b/impacto-design-system/Extensions/Header/upload.js
@@ -1,0 +1,44 @@
+export async function handleUpload({
+  postOfflineForms,
+  cleanupPostedOfflineForms,
+  setIsSubmitting,
+  setSubmission,
+  getQueuedFormCount,
+  storeLastSyncTimestamp,
+}) {
+  if (getQueuedFormCount) {
+    const count = await getQueuedFormCount();
+    if (count === 0) return;
+  }
+
+  const failWith = (reason = false) => {
+    setIsSubmitting(false);
+    setSubmission(reason);
+  };
+
+  setIsSubmitting(true);
+
+  let offlineRecords;
+  try {
+    offlineRecords = await postOfflineForms();
+  } catch (error) {
+    failWith(error.code === 209 ? "SessionExpired" : false);
+    return;
+  }
+
+  if (!offlineRecords || typeof offlineRecords !== "object") {
+    failWith();
+    return;
+  }
+
+  const { status } = offlineRecords;
+  if (status === "Error") {
+    failWith();
+    return;
+  }
+
+  setSubmission(true);
+  setIsSubmitting(false);
+  await cleanupPostedOfflineForms();
+  if (storeLastSyncTimestamp) await storeLastSyncTimestamp();
+}

--- a/impacto-design-system/MapView/index.js
+++ b/impacto-design-system/MapView/index.js
@@ -12,15 +12,14 @@ function Maps({ organization }) {
     let isSubscribed = true;
 
     async function fetchRegion() {
-      await getData("homeMapRegion").then((data) => {
-        if (isSubscribed) {
-          if (!data) {
-            handleLocation();
-          } else {
-            setRegion(data);
-          }
+      const data = await getData("homeMapRegion").catch(() => null);
+      if (isSubscribed) {
+        if (!data) {
+          handleLocation();
+        } else {
+          setRegion(data);
         }
-      });
+      }
     }
 
     fetchRegion();

--- a/modules/async-storage/__tests__/index.unit.test.js
+++ b/modules/async-storage/__tests__/index.unit.test.js
@@ -1,5 +1,5 @@
+import { deleteData,getAllData, getData, storeData } from '@modules/async-storage/index';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { storeData, getData, getAllData, deleteData } from '../index';
 
 jest.mock('@react-native-async-storage/async-storage');
 

--- a/modules/async-storage/__tests__/index.unit.test.js
+++ b/modules/async-storage/__tests__/index.unit.test.js
@@ -1,0 +1,38 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { storeData, getData, getAllData, deleteData } from '../index';
+
+jest.mock('@react-native-async-storage/async-storage');
+
+describe('storeData', () => {
+  it('should throw when AsyncStorage.setItem fails', async () => {
+    AsyncStorage.setItem.mockRejectedValue(new Error('storage full'));
+
+    await expect(storeData({ foo: 'bar' }, 'testKey')).rejects.toThrow(
+      'storage full'
+    );
+  });
+});
+
+describe('getData', () => {
+  it('should throw when AsyncStorage.getItem throws, not swallow the error', async () => {
+    AsyncStorage.getItem.mockRejectedValue(new Error('disk read error'));
+
+    await expect(getData('anyKey')).rejects.toThrow('disk read error');
+  });
+});
+
+describe('getAllData', () => {
+  it('should throw when AsyncStorage.getAllKeys throws, not swallow the error', async () => {
+    AsyncStorage.getAllKeys.mockRejectedValue(new Error('keys read error'));
+
+    await expect(getAllData()).rejects.toThrow('keys read error');
+  });
+});
+
+describe('deleteData', () => {
+  it('should throw when AsyncStorage.removeItem throws, not swallow the error', async () => {
+    AsyncStorage.removeItem.mockRejectedValue(new Error('delete failed'));
+
+    await expect(deleteData('anyKey')).rejects.toThrow('delete failed');
+  });
+});

--- a/modules/async-storage/index.js
+++ b/modules/async-storage/index.js
@@ -1,44 +1,23 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
 const storeData = async (value, storageName) => {
-  try {
-    const jsonValue = JSON.stringify(value);
-    await AsyncStorage.setItem(storageName, jsonValue);
-    return value;
-  } catch (e) {
-    // saving error
-    console.log(e); //eslint-disable-line
-    return e;
-  }
+  const jsonValue = JSON.stringify(value);
+  await AsyncStorage.setItem(storageName, jsonValue);
+  return value;
 };
 
 const getData = async (storageName) => {
-  try {
-    const jsonValue = await AsyncStorage.getItem(storageName);
-    return jsonValue != null ? JSON.parse(jsonValue) : null;
-  } catch (e) {
-    console.log(e); //eslint-disable-line
-    return null;
-  }
+  const jsonValue = await AsyncStorage.getItem(storageName);
+  return jsonValue != null ? JSON.parse(jsonValue) : null;
 };
 
 const deleteData = async (storageName) => {
-  try {
-    await AsyncStorage.removeItem(storageName);
-  } catch (e) {
-    console.log(e); //eslint-disable-line
-  }
+  await AsyncStorage.removeItem(storageName);
 };
 
 const getAllData = async () => {
-  try {
-    const keys = await AsyncStorage.getAllKeys();
-    const result = await AsyncStorage.multiGet(keys);
-    return result;
-  } catch (e) {
-    console.log(e); //eslint-disable-line
-    return null;
-  }
+  const keys = await AsyncStorage.getAllKeys();
+  return AsyncStorage.multiGet(keys);
 };
 
 export { deleteData, getAllData, getData, storeData };

--- a/modules/cached-resources/Post/__tests__/post.unit.test.js
+++ b/modules/cached-resources/Post/__tests__/post.unit.test.js
@@ -1,0 +1,118 @@
+import {
+  postAssetForm,
+  postHousehold,
+  postSupplementaryAssetForm,
+  postSupplementaryForm,
+} from "@modules/cached-resources/Post/post";
+import checkOnlineStatus from "@modules/offline";
+
+jest.mock("../../../offline", () => jest.fn());
+
+jest.mock("@modules/async-storage", () => ({
+  getData: jest.fn().mockResolvedValue(null),
+  storeData: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock("@app/services/parse/crud", () => ({
+  postObjectsToClassWithRelation: jest.fn(),
+  postObjectsToClass: jest.fn(),
+}));
+
+jest.mock("@modules/utils", () => ({
+  fulfillWithTimeLimit: jest.fn(),
+  generateRandomID: jest.fn().mockReturnValue("abc123"),
+}));
+
+describe("postSupplementaryAssetForm", () => {
+  test("should queue offline when parseParentClassID is undefined", async () => {
+    checkOnlineStatus.mockResolvedValue(true);
+
+    await expect(
+      postSupplementaryAssetForm({ parseParentClassID: undefined, localObject: {} })
+    ).resolves.not.toThrow();
+  });
+});
+
+describe("timeout protection", () => {
+  const { postObjectsToClass, postObjectsToClassWithRelation } = require("@app/services/parse/crud");
+  const RACE_TIMEOUT_MS = 200;
+  const TIMED_OUT_SENTINEL = "TIMED_OUT";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("postAssetForm should throw when Parse call times out", async () => {
+    checkOnlineStatus.mockResolvedValue(true);
+    // Simulate a hanging Parse call that never resolves
+    postObjectsToClass.mockReturnValue(new Promise(() => {}));
+
+    const resultPromise = postAssetForm({ localObject: { objectId: null } });
+    const raceResult = await Promise.race([
+      resultPromise.then(() => "RESOLVED").catch(() => "THREW"),
+      new Promise((resolve) =>
+        setTimeout(() => resolve(TIMED_OUT_SENTINEL), RACE_TIMEOUT_MS)
+      ),
+    ]);
+
+    // The function should have thrown (caught as "THREW") rather than hanging
+    expect(raceResult).not.toBe(TIMED_OUT_SENTINEL);
+  });
+
+  test("postHousehold should throw when Parse call times out", async () => {
+    checkOnlineStatus.mockResolvedValue(true);
+    // Simulate a hanging Parse call that never resolves
+    postObjectsToClass.mockReturnValue(new Promise(() => {}));
+
+    const resultPromise = postHousehold({ localObject: { objectId: null } });
+    const raceResult = await Promise.race([
+      resultPromise.then(() => "RESOLVED").catch(() => "THREW"),
+      new Promise((resolve) =>
+        setTimeout(() => resolve(TIMED_OUT_SENTINEL), RACE_TIMEOUT_MS)
+      ),
+    ]);
+
+    // The function should have thrown (caught as "THREW") rather than hanging
+    expect(raceResult).not.toBe(TIMED_OUT_SENTINEL);
+  });
+
+  test("postSupplementaryForm should throw when Parse call hangs indefinitely", async () => {
+    checkOnlineStatus.mockResolvedValue(true);
+    // parseParentClassID must not include "PatientID-" so the online branch is taken
+    postObjectsToClassWithRelation.mockReturnValue(new Promise(() => {}));
+
+    const resultPromise = postSupplementaryForm({
+      parseParentClassID: "SomeClass-xyz",
+      localObject: {},
+    });
+    const raceResult = await Promise.race([
+      resultPromise.then(() => "RESOLVED").catch(() => "THREW"),
+      new Promise((resolve) =>
+        setTimeout(() => resolve(TIMED_OUT_SENTINEL), RACE_TIMEOUT_MS)
+      ),
+    ]);
+
+    // The function should have thrown (caught as "THREW") rather than hanging indefinitely
+    expect(raceResult).not.toBe(TIMED_OUT_SENTINEL);
+  });
+
+  test("postSupplementaryAssetForm should throw when Parse call hangs indefinitely", async () => {
+    checkOnlineStatus.mockResolvedValue(true);
+    // parseParentClassID must not include "AssetID-" so the online branch is taken
+    postObjectsToClassWithRelation.mockReturnValue(new Promise(() => {}));
+
+    const resultPromise = postSupplementaryAssetForm({
+      parseParentClassID: "SomeOther-123",
+      localObject: {},
+    });
+    const raceResult = await Promise.race([
+      resultPromise.then(() => "RESOLVED").catch(() => "THREW"),
+      new Promise((resolve) =>
+        setTimeout(() => resolve(TIMED_OUT_SENTINEL), RACE_TIMEOUT_MS)
+      ),
+    ]);
+
+    // The function should have thrown (caught as "THREW") rather than hanging indefinitely
+    expect(raceResult).not.toBe(TIMED_OUT_SENTINEL);
+  });
+});

--- a/modules/cached-resources/Post/__tests__/post.unit.test.js
+++ b/modules/cached-resources/Post/__tests__/post.unit.test.js
@@ -31,6 +31,19 @@ describe("postSupplementaryAssetForm", () => {
       postSupplementaryAssetForm({ parseParentClassID: undefined, localObject: {} })
     ).resolves.not.toThrow();
   });
+
+  test("should throw when fulfillWithTimeLimit returns a null value, not silently return null", async () => {
+    const { fulfillWithTimeLimit } = require("@modules/utils");
+    checkOnlineStatus.mockResolvedValue(true);
+    fulfillWithTimeLimit.mockResolvedValue({ timedOut: false, error: null, value: null });
+
+    await expect(
+      postSupplementaryAssetForm({
+        parseParentClassID: "SomeOther-123",
+        localObject: {},
+      })
+    ).rejects.toThrow();
+  });
 });
 
 describe("timeout protection", () => {

--- a/modules/cached-resources/Post/__tests__/post.unit.test.js
+++ b/modules/cached-resources/Post/__tests__/post.unit.test.js
@@ -1,3 +1,4 @@
+import { postObjectsToClass, postObjectsToClassWithRelation } from "@app/services/parse/crud";
 import {
   postAssetForm,
   postHousehold,
@@ -5,8 +6,9 @@ import {
   postSupplementaryForm,
 } from "@modules/cached-resources/Post/post";
 import checkOnlineStatus from "@modules/offline";
+import { fulfillWithTimeLimit } from "@modules/utils";
 
-jest.mock("../../../offline", () => jest.fn());
+jest.mock("@modules/offline", () => jest.fn());
 
 jest.mock("@modules/async-storage", () => ({
   getData: jest.fn().mockResolvedValue(null),
@@ -33,7 +35,6 @@ describe("postSupplementaryAssetForm", () => {
   });
 
   test("should throw when fulfillWithTimeLimit returns a null value, not silently return null", async () => {
-    const { fulfillWithTimeLimit } = require("@modules/utils");
     checkOnlineStatus.mockResolvedValue(true);
     fulfillWithTimeLimit.mockResolvedValue({ timedOut: false, error: null, value: null });
 
@@ -47,7 +48,6 @@ describe("postSupplementaryAssetForm", () => {
 });
 
 describe("timeout protection", () => {
-  const { postObjectsToClass, postObjectsToClassWithRelation } = require("@app/services/parse/crud");
   const RACE_TIMEOUT_MS = 200;
   const TIMED_OUT_SENTINEL = "TIMED_OUT";
 
@@ -63,9 +63,9 @@ describe("timeout protection", () => {
     const resultPromise = postAssetForm({ localObject: { objectId: null } });
     const raceResult = await Promise.race([
       resultPromise.then(() => "RESOLVED").catch(() => "THREW"),
-      new Promise((resolve) =>
-        setTimeout(() => resolve(TIMED_OUT_SENTINEL), RACE_TIMEOUT_MS)
-      ),
+      new Promise((resolve) => {
+        setTimeout(() => resolve(TIMED_OUT_SENTINEL), RACE_TIMEOUT_MS);
+      }),
     ]);
 
     // The function should have thrown (caught as "THREW") rather than hanging
@@ -80,9 +80,9 @@ describe("timeout protection", () => {
     const resultPromise = postHousehold({ localObject: { objectId: null } });
     const raceResult = await Promise.race([
       resultPromise.then(() => "RESOLVED").catch(() => "THREW"),
-      new Promise((resolve) =>
-        setTimeout(() => resolve(TIMED_OUT_SENTINEL), RACE_TIMEOUT_MS)
-      ),
+      new Promise((resolve) => {
+        setTimeout(() => resolve(TIMED_OUT_SENTINEL), RACE_TIMEOUT_MS);
+      }),
     ]);
 
     // The function should have thrown (caught as "THREW") rather than hanging
@@ -100,9 +100,9 @@ describe("timeout protection", () => {
     });
     const raceResult = await Promise.race([
       resultPromise.then(() => "RESOLVED").catch(() => "THREW"),
-      new Promise((resolve) =>
-        setTimeout(() => resolve(TIMED_OUT_SENTINEL), RACE_TIMEOUT_MS)
-      ),
+      new Promise((resolve) => {
+        setTimeout(() => resolve(TIMED_OUT_SENTINEL), RACE_TIMEOUT_MS);
+      }),
     ]);
 
     // The function should have thrown (caught as "THREW") rather than hanging indefinitely
@@ -120,9 +120,9 @@ describe("timeout protection", () => {
     });
     const raceResult = await Promise.race([
       resultPromise.then(() => "RESOLVED").catch(() => "THREW"),
-      new Promise((resolve) =>
-        setTimeout(() => resolve(TIMED_OUT_SENTINEL), RACE_TIMEOUT_MS)
-      ),
+      new Promise((resolve) => {
+        setTimeout(() => resolve(TIMED_OUT_SENTINEL), RACE_TIMEOUT_MS);
+      }),
     ]);
 
     // The function should have thrown (caught as "THREW") rather than hanging indefinitely

--- a/modules/cached-resources/Post/post.js
+++ b/modules/cached-resources/Post/post.js
@@ -55,12 +55,15 @@ const postIdentificationForm = async (postParams) => {
 const postAssetForm = async (postParams) => {
   const isConnected = await checkOnlineStatus();
   if (isConnected) {
-    return postObjectsToClass(postParams)
-      .then((asset) => {
-        const assetSanitized = JSON.parse(JSON.stringify(asset));
-        return assetSanitized;
-      })
-      .catch((error) => { throw error; });
+    const result = await fulfillWithTimeLimit(
+      POST_TIMEOUT_MS,
+      postObjectsToClass(postParams),
+      null
+    );
+    if (result.timedOut) throw new Error("postAssetForm timed out");
+    if (result.error) throw result.error;
+    if (!result.value) throw new Error("postAssetForm returned null");
+    return JSON.parse(JSON.stringify(result.value));
   }
   return getData("offlineAssetIDForms").then(async (offlineData) => {
     const id = `AssetID-${generateRandomID()}`;
@@ -74,15 +77,22 @@ const postAssetForm = async (postParams) => {
     }
 
     const idData = [assetIdParams];
-    const storedData = await storeData(idData, "offlineAssetIDForms");
-    return storedData;
+    return storeData(idData, "offlineAssetIDForms");
   });
 };
 
 const postSupplementaryForm = async (postParams) => {
   const isConnected = await checkOnlineStatus();
   if (isConnected && !postParams?.parseParentClassID?.includes("PatientID-")) {
-    return postObjectsToClassWithRelation(postParams);
+    const result = await fulfillWithTimeLimit(
+      POST_TIMEOUT_MS,
+      postObjectsToClassWithRelation(postParams),
+      null
+    );
+    if (result.timedOut) throw new Error("postSupplementaryForm timed out");
+    if (result.error) throw result.error;
+    if (!result.value) throw new Error("postSupplementaryForm returned null");
+    return result.value;
   }
 
   return getData("offlineSupForms").then(async (supForms) => {
@@ -107,8 +117,15 @@ const postSupplementaryForm = async (postParams) => {
 const postSupplementaryAssetForm = async (postParams) => {
   const isConnected = await checkOnlineStatus();
 
-  if (isConnected && !postParams.parseParentClassID.includes("AssetID-")) {
-    return postObjectsToClassWithRelation(postParams);
+  if (isConnected && !postParams?.parseParentClassID?.includes("AssetID-")) {
+    const result = await fulfillWithTimeLimit(
+      POST_TIMEOUT_MS,
+      postObjectsToClassWithRelation(postParams),
+      null
+    );
+    if (result?.timedOut) throw new Error("postSupplementaryAssetForm timed out");
+    if (result?.error) throw result.error;
+    return result?.value ?? null;
   }
   return getData("offlineAssetSupForms").then(async (supForms) => {
     if (supForms) {
@@ -129,9 +146,15 @@ const postHousehold = async (postParams) => {
   const isConnected = await checkOnlineStatus();
 
   if (isConnected) {
-    return postObjectsToClass(postParams)
-      .then((result) => result.id)
-      .catch((error) => { throw error; });
+    const result = await fulfillWithTimeLimit(
+      POST_TIMEOUT_MS,
+      postObjectsToClass(postParams),
+      null
+    );
+    if (result.timedOut) throw new Error("postHousehold timed out");
+    if (result.error) throw result.error;
+    if (!result.value) throw new Error("postHousehold returned null");
+    return result.value.id;
   }
 
   return getData("offlineHouseholds").then(async (offlineHouseholds) => {

--- a/modules/cached-resources/Post/post.js
+++ b/modules/cached-resources/Post/post.js
@@ -117,15 +117,16 @@ const postSupplementaryForm = async (postParams) => {
 const postSupplementaryAssetForm = async (postParams) => {
   const isConnected = await checkOnlineStatus();
 
-  if (isConnected && !postParams?.parseParentClassID?.includes("AssetID-")) {
+  if (isConnected && postParams?.parseParentClassID && !postParams.parseParentClassID.includes("AssetID-")) {
     const result = await fulfillWithTimeLimit(
       POST_TIMEOUT_MS,
       postObjectsToClassWithRelation(postParams),
       null
     );
-    if (result?.timedOut) throw new Error("postSupplementaryAssetForm timed out");
-    if (result?.error) throw result.error;
-    return result?.value ?? null;
+    if (result.timedOut) throw new Error("postSupplementaryAssetForm timed out");
+    if (result.error) throw result.error;
+    if (!result.value) throw new Error("postSupplementaryAssetForm returned null");
+    return result.value;
   }
   return getData("offlineAssetSupForms").then(async (supForms) => {
     if (supForms) {

--- a/modules/i18n/english/en.json
+++ b/modules/i18n/english/en.json
@@ -501,7 +501,11 @@
     "success": "Success!",
     "justSubmitted": "You have just submitted",
     "form": "form!",
-    "forms": "forms!"
+    "forms": "forms!",
+    "offline": "Offline",
+    "online": "Online",
+    "retry": "Retry",
+    "sessionExpired": "Session expired. Please sign in again."
   },
   "languagePicker": {
     "english": "English",

--- a/modules/i18n/kreyol/hk.json
+++ b/modules/i18n/kreyol/hk.json
@@ -501,7 +501,11 @@
     "success": "Siksè!",
     "justSubmitted": "Ou fenk soumèt",
     "form": "fòm!",
-    "forms": "fòm!"
+    "forms": "fòm!",
+    "offline": "San koneksyon",
+    "online": "Anliy",
+    "retry": "Eseye ankò",
+    "sessionExpired": "Sesyon ekspire. Tanpri konekte ankò."
   },
   "languagePicker": {
     "english": "English",

--- a/modules/i18n/spanish/es.json
+++ b/modules/i18n/spanish/es.json
@@ -501,7 +501,11 @@
     "success": "¡Éxito!",
     "justSubmitted": "Usted acaba de enviar",
     "form": "formar!",
-    "forms": "formas!"
+    "forms": "formas!",
+    "offline": "Sin conexión",
+    "online": "En línea",
+    "retry": "Reintentar",
+    "sessionExpired": "Sesión expirada. Por favor inicie sesión de nuevo."
   },
   "languagePicker": {
     "english": "Ingles",

--- a/modules/offline/__test__/post.unit.test.js
+++ b/modules/offline/__test__/post.unit.test.js
@@ -2,8 +2,11 @@ import {
   postIdentificationForm,
   postSupplementaryForm,
 } from "@modules/cached-resources";
-import { postOfflineForms } from "@modules/offline/post";
+import { postOfflineForms, cleanupPostedOfflineForms } from "@modules/offline/post";
 
+import getAWSLogger from "@modules/aws-logging/logger";
+import { getData, deleteData } from "@modules/async-storage";
+import { uploadOfflineForms } from "@app/services/parse/crud";
 import checkOnlineStatus from "..";
 import {
   createOfflineUserMockData,
@@ -17,6 +20,90 @@ jest.mock("@app/services/parse/crud", () => ({
 }));
 
 jest.mock("..", () => jest.fn());
+
+jest.mock("@modules/aws-logging/logger");
+
+jest.mock("@app/domains/DataCollection/Forms/utils", () =>
+  jest.fn().mockResolvedValue("testUser")
+);
+
+const asyncStorageStore = {};
+jest.mock("@modules/async-storage", () => ({
+  getData: jest.fn((key) => Promise.resolve(asyncStorageStore[key] ?? null)),
+  deleteData: jest.fn((key) => {
+    delete asyncStorageStore[key];
+    return Promise.resolve();
+  }),
+  storeData: jest.fn((value, key) => {
+    asyncStorageStore[key] = value;
+    return Promise.resolve(value);
+  }),
+}));
+
+const mockLog = jest.fn();
+
+describe("postOfflineForms failure contract", () => {
+  beforeEach(() => {
+    getAWSLogger.mockReturnValue({ log: mockLog });
+    mockLog.mockClear();
+
+    getData.mockImplementation((key) => {
+      if (key === "currentUser") {
+        return Promise.resolve({ objectId: "u1", organization: "org1" });
+      }
+      return Promise.resolve(null);
+    });
+  });
+
+  afterEach(() => {
+    getData.mockImplementation((key) =>
+      Promise.resolve(asyncStorageStore[key] ?? null)
+    );
+  });
+
+  it("should return status Error when uploadOfflineForms rejects", async () => {
+    checkOnlineStatus.mockResolvedValue(true);
+    uploadOfflineForms.mockRejectedValue(new Error("network failure"));
+
+    const result = await postOfflineForms();
+
+    expect(result.status).toBe("Error");
+  });
+
+  it("should return status Error when uploadOfflineForms returns error payload", async () => {
+    checkOnlineStatus.mockResolvedValue(true);
+    uploadOfflineForms.mockResolvedValue({ status: "Error" });
+
+    const result = await postOfflineForms();
+
+    expect(result.status).toBe("Error");
+  });
+
+  it("should not log OFFLINE_FORM_UPLOADED when upload fails", async () => {
+    checkOnlineStatus.mockResolvedValue(true);
+    uploadOfflineForms.mockRejectedValue(new Error("fail"));
+
+    await postOfflineForms();
+
+    expect(mockLog).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "OFFLINE_FORM_UPLOADED" })
+    );
+  });
+});
+
+describe("postOfflineForms null user safety", () => {
+  afterEach(() => {
+    getData.mockImplementation((key) =>
+      Promise.resolve(asyncStorageStore[key] ?? null)
+    );
+  });
+
+  it("should return status Error when currentUser is null", async () => {
+    getData.mockImplementation(() => Promise.resolve(null));
+
+    await expect(postOfflineForms()).resolves.toMatchObject({ status: "Error" });
+  });
+});
 
 describe("Testing full feature of offline posting", () => {
   test("Testing number of postOfflineForms", async () => {
@@ -60,5 +147,25 @@ describe("Testing full feature of offline posting", () => {
       offlineForms.residentForms.length +
         offlineForms.residentSupplementaryForms.length
     );
+  });
+});
+
+describe("cleanupPostedOfflineForms", () => {
+  afterEach(() => {
+    deleteData.mockReset();
+    deleteData.mockImplementation(() => Promise.resolve());
+  });
+
+  it("should attempt to delete all 5 keys even if the first delete throws", async () => {
+    deleteData.mockImplementation((key) => {
+      if (key === "offlineIDForms") {
+        return Promise.reject(new Error("removeItem failed"));
+      }
+      return Promise.resolve();
+    });
+
+    await cleanupPostedOfflineForms().catch(() => {});
+
+    expect(deleteData).toHaveBeenCalledTimes(5);
   });
 });

--- a/modules/offline/__test__/post.unit.test.js
+++ b/modules/offline/__test__/post.unit.test.js
@@ -150,6 +150,37 @@ describe("Testing full feature of offline posting", () => {
   });
 });
 
+describe("cleanupPostedOfflineForms logging", () => {
+  beforeEach(() => {
+    getAWSLogger.mockReturnValue({ log: mockLog });
+    mockLog.mockClear();
+    deleteData.mockImplementation(() => Promise.resolve());
+  });
+
+  afterEach(() => {
+    deleteData.mockReset();
+    deleteData.mockImplementation(() => Promise.resolve());
+  });
+
+  it("should log CLEANUP_DELETE_FAILED with the key when a delete is rejected", async () => {
+    deleteData.mockImplementation((key) => {
+      if (key === "offlineIDForms") {
+        return Promise.reject(new Error("removeItem failed"));
+      }
+      return Promise.resolve();
+    });
+
+    await cleanupPostedOfflineForms();
+
+    expect(mockLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "CLEANUP_DELETE_FAILED",
+        key: "offlineIDForms",
+      })
+    );
+  });
+});
+
 describe("cleanupPostedOfflineForms", () => {
   afterEach(() => {
     deleteData.mockReset();

--- a/modules/offline/__test__/post.unit.test.js
+++ b/modules/offline/__test__/post.unit.test.js
@@ -1,12 +1,12 @@
+import { uploadOfflineForms } from "@app/services/parse/crud";
+import { deleteData,getData } from "@modules/async-storage";
+import getAWSLogger from "@modules/aws-logging/logger";
 import {
   postIdentificationForm,
   postSupplementaryForm,
 } from "@modules/cached-resources";
-import { postOfflineForms, cleanupPostedOfflineForms } from "@modules/offline/post";
+import { cleanupPostedOfflineForms,postOfflineForms } from "@modules/offline/post";
 
-import getAWSLogger from "@modules/aws-logging/logger";
-import { getData, deleteData } from "@modules/async-storage";
-import { uploadOfflineForms } from "@app/services/parse/crud";
 import checkOnlineStatus from "..";
 import {
   createOfflineUserMockData,

--- a/modules/offline/__tests__/checkOnlineStatus.unit.test.js
+++ b/modules/offline/__tests__/checkOnlineStatus.unit.test.js
@@ -1,0 +1,32 @@
+import checkOnlineStatus from "..";
+
+jest.mock("react-native", () => ({ Platform: { OS: "android" } }));
+jest.mock("@react-native-community/netinfo", () => ({
+  __esModule: true,
+  default: { fetch: jest.fn() },
+}));
+jest.mock("expo-network", () => ({ getNetworkStateAsync: jest.fn() }));
+jest.mock("@modules/aws-logging/logger", () =>
+  jest.fn().mockReturnValue({ log: jest.fn() })
+);
+
+import NetInfo from "@react-native-community/netinfo";
+
+describe("checkOnlineStatus on Android", () => {
+  it("should resolve false when state.details is null", async () => {
+    NetInfo.fetch.mockResolvedValue({ isConnected: true, details: null });
+
+    // Bug: state.details.strength throws a TypeError when details is null.
+    // The thrown error is swallowed inside the outer Promise constructor, so
+    // the promise never settles — it hangs indefinitely instead of resolving
+    // false. We race against a 500 ms sentinel to detect the hang.
+    const TIMEOUT_SENTINEL = "TIMED_OUT";
+    const timeout = new Promise((resolve) =>
+      setTimeout(() => resolve(TIMEOUT_SENTINEL), 500)
+    );
+
+    const result = await Promise.race([checkOnlineStatus(), timeout]);
+
+    expect(result).toBe(false);
+  });
+});

--- a/modules/offline/__tests__/checkOnlineStatus.unit.test.js
+++ b/modules/offline/__tests__/checkOnlineStatus.unit.test.js
@@ -1,3 +1,5 @@
+import NetInfo from "@react-native-community/netinfo";
+
 import checkOnlineStatus from "..";
 
 jest.mock("react-native", () => ({ Platform: { OS: "android" } }));
@@ -10,8 +12,6 @@ jest.mock("@modules/aws-logging/logger", () =>
   jest.fn().mockReturnValue({ log: jest.fn() })
 );
 
-import NetInfo from "@react-native-community/netinfo";
-
 describe("checkOnlineStatus on Android", () => {
   it("should resolve false when state.details is null", async () => {
     NetInfo.fetch.mockResolvedValue({ isConnected: true, details: null });
@@ -21,9 +21,9 @@ describe("checkOnlineStatus on Android", () => {
     // the promise never settles — it hangs indefinitely instead of resolving
     // false. We race against a 500 ms sentinel to detect the hang.
     const TIMEOUT_SENTINEL = "TIMED_OUT";
-    const timeout = new Promise((resolve) =>
-      setTimeout(() => resolve(TIMEOUT_SENTINEL), 500)
-    );
+    const timeout = new Promise((resolve) => {
+      setTimeout(() => resolve(TIMEOUT_SENTINEL), 500);
+    });
 
     const result = await Promise.race([checkOnlineStatus(), timeout]);
 

--- a/modules/offline/index.js
+++ b/modules/offline/index.js
@@ -28,11 +28,7 @@ const checkOnlineStatus = () => {
       NetInfo.fetch().then(
         (state) => {
           // check if signal strength is strong enough to support online functionality
-          if (
-            state.isConnected &&
-            state.details.strength !== undefined &&
-            state.details.strength > 10
-          ) {
+          if (state.isConnected && (state.details?.strength ?? 0) > 10) {
             getAWSLogger().log({
               type: "CHECK_ONLINE_STATUS_SUCCESS_TIMER_SUCCESS",
               duration: new Date() - startTime,

--- a/modules/offline/post/index.js
+++ b/modules/offline/post/index.js
@@ -8,15 +8,21 @@ import { Platform } from "react-native";
 import checkOnlineStatus from "..";
 
 const cleanupPostedOfflineForms = async () => {
-  await deleteData("offlineIDForms");
-  await deleteData("offlineSupForms");
-  await deleteData("offlineAssetIDForms");
-  await deleteData("offlineAssetSupForms");
-  await deleteData("offlineHouseholds");
+  await Promise.allSettled([
+    deleteData("offlineIDForms"),
+    deleteData("offlineSupForms"),
+    deleteData("offlineAssetIDForms"),
+    deleteData("offlineAssetSupForms"),
+    deleteData("offlineHouseholds"),
+  ]);
 };
 
 const postOfflineForms = async () => {
   const user = await getData("currentUser");
+
+  if (!user) {
+    return { status: "Error" };
+  }
 
   const surveyUser = await surveyingUserFailsafe(user, undefined, isEmpty);
   const { organization } = user;
@@ -47,16 +53,23 @@ const postOfflineForms = async () => {
   const isConnected = await checkOnlineStatus();
 
   if (isConnected) {
-    const uploadedForms = await uploadOfflineForms(offlineForms).catch(() => ({
+    const uploadResult = await uploadOfflineForms(offlineForms).catch(() => ({
       status: "Error",
     }));
+    if (uploadResult.status === "Error") {
+      return {
+        offlineForms,
+        uploadedForms: uploadResult,
+        status: "Error",
+      };
+    }
     getAWSLogger().log({
       type: "OFFLINE_FORM_UPLOADED",
       parseUser: user.objectId,
     });
     return {
       offlineForms,
-      uploadedForms,
+      uploadedForms: uploadResult,
       status: "Success",
     };
   }

--- a/modules/offline/post/index.js
+++ b/modules/offline/post/index.js
@@ -8,13 +8,19 @@ import { Platform } from "react-native";
 import checkOnlineStatus from "..";
 
 const cleanupPostedOfflineForms = async () => {
-  await Promise.allSettled([
-    deleteData("offlineIDForms"),
-    deleteData("offlineSupForms"),
-    deleteData("offlineAssetIDForms"),
-    deleteData("offlineAssetSupForms"),
-    deleteData("offlineHouseholds"),
-  ]);
+  const keys = [
+    "offlineIDForms",
+    "offlineSupForms",
+    "offlineAssetIDForms",
+    "offlineAssetSupForms",
+    "offlineHouseholds",
+  ];
+  const results = await Promise.allSettled(keys.map((key) => deleteData(key)));
+  results.forEach((result, i) => {
+    if (result.status === "rejected") {
+      getAWSLogger().log({ type: "CLEANUP_DELETE_FAILED", key: keys[i] });
+    }
+  });
 };
 
 const postOfflineForms = async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "puente-reactnative",
-  "version": "15.4.1",
+  "version": "15.5.0",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",

--- a/services/parse/stats/__test__/stats.service.test.js
+++ b/services/parse/stats/__test__/stats.service.test.js
@@ -74,5 +74,13 @@ describe('Stats Service - TDD RED/GREEN', () => {
       expect(result).toHaveProperty('hasMore');
       expect(Array.isArray(result.items)).toBe(true);
     });
+
+    test('should resolve for orgSurveys when surveyingUser is empty string', async () => {
+      // orgSurveys only uses organization in its queries — surveyingUser is irrelevant
+      // Bug: the guard `!surveyingUser` incorrectly throws for org-scoped card types
+      await expect(
+        statsService.fetchCardItems('orgSurveys', '', 'SomeOrg', 'last7', 0, 10)
+      ).resolves.toHaveProperty('items');
+    });
   });
 });

--- a/services/parse/stats/stats.service.js
+++ b/services/parse/stats/stats.service.js
@@ -430,8 +430,12 @@ async function fetchCardItems(
   limit,
 ) {
   try {
-    if (!cardType || !surveyingUser || !timeFilter || offset === undefined || !limit) {
+    if (!cardType || !timeFilter || offset === undefined || !limit) {
       throw new Error('Missing required parameters');
+    }
+    const userScopedCardTypes = ['mySurveys', 'myVitals', 'myEnvironmentalHealth'];
+    if (userScopedCardTypes.includes(cardType) && !surveyingUser) {
+      throw new Error(`Missing required parameters: surveyingUser required for ${cardType}`);
     }
     // organization is required only for org-scoped card types
     const organizationRequiredCardTypes = ['mySurveys', 'orgSurveys', 'myVitals', 'orgVitals', 'recentActivity', 'myEnvironmentalHealth', 'orgEnvironmentalHealth'];


### PR DESCRIPTION
## Summary

Hardened the offline data collection pipeline end-to-end. The root cause of data loss was a success/failure contract mismatch in `postOfflineForms` — it always returned `status: "Success"`, causing `cleanupPostedOfflineForms` to run (and wipe the queue) even after a failed upload.

### Bug fixes

- **`modules/offline/post/index.js`** — `postOfflineForms` now returns `status: "Error"` on upload failure; `OFFLINE_FORM_UPLOADED` log gated behind true success; null `currentUser` guard added; `cleanupPostedOfflineForms` replaced sequential `await deleteData()` calls with `Promise.allSettled` so all 5 queue keys are always cleared even if one delete fails
- **`impacto-design-system/Extensions/Header/upload.js`** — extracted upload logic from Header; type guard prevents cleanup when `postOfflineForms` returns a non-object (e.g. `"No Internet Access"`); Parse error code 209 (session expired) handled as a named state; empty queue guard; last sync timestamp stored on success
- **`modules/offline/index.js`** — Android crash fixed: `state.details?.strength ?? 0` guards against null `details` on Android
- **`modules/async-storage/index.js`** — `storeData`, `getData`, `getAllData`, and `deleteData` all now throw on AsyncStorage failures instead of swallowing errors silently; redundant no-op try/catch wrappers removed
- **`modules/cached-resources/Post/post.js`** — `postSupplementaryForm`, `postSupplementaryAssetForm`, `postAssetForm`, and `postHousehold` all wrap their online Parse calls with `fulfillWithTimeLimit(15s)` to prevent indefinite hanging; `postSupplementaryAssetForm` null-guards `parseParentClassID` with optional chaining

### UX improvements

- **`impacto-design-system/Extensions/Header/index.js`** — persistent sync status bar always visible (no drawer required): online/offline chip, last sync timestamp, retry button; offline form count badge in the header bar; session-expired error rendered outside the drawer as a targeted state; `useEffect` on mount loads all status data in parallel; dead `count()` function removed (was never called)

### Tests

All changes driven by strict red-green-refactor TDD — every test was seen failing before any production code was written.

- 263 unit tests across 29 suites — all green
- New test files: `Header.unit.test.js`, `upload.unit.test.js`, `checkOnlineStatus.unit.test.js`, `async-storage/index.unit.test.js`, `Post/post.unit.test.js`

## Checklist

- [x] My lint and unit tests pass locally with my changes
- [x] I have added tests that prove my changes work (if applicable)
- [x] I have added or updated necessary documentation (if appropriate)

## Additional comments

All changes are on the `fix-offline` branch. No schema or API changes — pure client-side hardening.