### PR TITLE
fix: don't wipe the offline queue when the server reports a save failure

### DIFF
--- a/impacto-design-system/Extensions/Header/__tests__/upload.unit.test.js
+++ b/impacto-design-system/Extensions/Header/__tests__/upload.unit.test.js
@@ -12,6 +12,20 @@ describe("handleUpload", () => {
     expect(cleanupPostedOfflineForms).not.toHaveBeenCalled();
   });
 
+  it("should not cleanup offline forms when postOfflineForms returns { status: 'Error' }", async () => {
+    // The queue is the only copy of un-synced field data; a failed upload
+    // must leave it on-device for retry.
+    const postOfflineForms = jest.fn().mockResolvedValue({ status: "Error" });
+    const cleanupPostedOfflineForms = jest.fn();
+    const setIsSubmitting = jest.fn();
+    const setSubmission = jest.fn();
+
+    await handleUpload({ postOfflineForms, cleanupPostedOfflineForms, setIsSubmitting, setSubmission });
+
+    expect(cleanupPostedOfflineForms).not.toHaveBeenCalled();
+    expect(setSubmission).toHaveBeenCalledWith(false);
+  });
+
   it("should call resetFormCount(0) after successful upload", async () => {
     const postOfflineForms = jest.fn().mockResolvedValue({ status: "Success", offlineForms: {}, uploadedForms: {} });
     const cleanupPostedOfflineForms = jest.fn().mockResolvedValue();

--- a/modules/offline/__test__/post.unit.test.js
+++ b/modules/offline/__test__/post.unit.test.js
@@ -71,6 +71,30 @@ describe("postOfflineForms failure contract", () => {
     expect(result.status).toBe("Error");
   });
 
+  it("should return status Error when the server resolves with an error-shaped payload", async () => {
+    // Cloud Code's Offline.upload catches save failures and RETURNS the error
+    // instead of throwing; a serialized Error crosses Parse as {}. Treating
+    // that as Success wipes the local queue — permanent field-data loss.
+    checkOnlineStatus.mockResolvedValue(true);
+    uploadOfflineForms.mockResolvedValue({});
+
+    const result = await postOfflineForms();
+
+    expect(result.status).toBe("Error");
+  });
+
+  it("should return status Error when the result is missing any upload category", async () => {
+    checkOnlineStatus.mockResolvedValue(true);
+    uploadOfflineForms.mockResolvedValue({
+      residentForms: [],
+      residentSupplementaryForms: [],
+      // households / assetForms / assetSupplementaryForms missing
+    });
+
+    const result = await postOfflineForms();
+
+    expect(result.status).toBe("Error");
+  });
 });
 
 describe("postOfflineForms null user safety", () => {
@@ -162,10 +186,14 @@ describe("postOfflineForms online success path", () => {
 
   it("should call uploadOfflineForms and return status Success when device is online from the start", async () => {
     checkOnlineStatus.mockResolvedValue(true);
+    // Mirror the real cloud function's success shape: all five categories,
+    // no status field of its own.
     uploadOfflineForms.mockResolvedValue({
-      status: "Success",
       residentForms: [],
       residentSupplementaryForms: [],
+      households: [],
+      assetForms: [],
+      assetSupplementaryForms: [],
     });
 
     const result = await postOfflineForms();

--- a/modules/offline/post/index.js
+++ b/modules/offline/post/index.js
@@ -6,6 +6,23 @@ import { Platform } from "react-native";
 
 import checkOnlineStatus from "..";
 
+// Cloud Code's success payload always carries all five categories as arrays.
+// Its Offline.upload catches save failures and RETURNS the error (a serialized
+// Error crosses Parse as {}), so anything missing a category means records
+// were not saved — the local queue must survive for retry.
+const UPLOAD_CATEGORIES = [
+  "residentForms",
+  "residentSupplementaryForms",
+  "households",
+  "assetForms",
+  "assetSupplementaryForms",
+];
+
+const isCompleteUploadResult = (result) =>
+  !!result &&
+  typeof result === "object" &&
+  UPLOAD_CATEGORIES.every((key) => Array.isArray(result[key]));
+
 const cleanupPostedOfflineForms = async () => {
   const keys = [
     "offlineIDForms",
@@ -71,7 +88,7 @@ const postOfflineForms = async () => {
     const uploadResult = await uploadOfflineForms(offlineForms).catch(() => ({
       status: "Error",
     }));
-    if (uploadResult.status === "Error") {
+    if (uploadResult.status === "Error" || !isCompleteUploadResult(uploadResult)) {
       return {
         offlineForms,
         uploadedForms: uploadResult,


### PR DESCRIPTION
## Problem
Cloud Code's `Offline.upload` catches save failures and **returns** the error instead of throwing. A serialized `Error` crosses Parse as `{}`, and `postOfflineForms` only checked `status === 'Error'` — so a failed upload was reported as **Success**, and `cleanupPostedOfflineForms` deleted the un-synced local records. Silent, permanent field-data loss.

## Fix
`postOfflineForms` now recognizes Success only when the payload has the real cloud-function success shape — all five upload categories (`residentForms`, `residentSupplementaryForms`, `households`, `assetForms`, `assetSupplementaryForms`) present as arrays. Anything else returns `status: 'Error'`, the queue stays on-device, and the user can retry.

## Tests (TDD)
- `server resolves with an error-shaped payload ({})` → **watched fail** before the fix (was treated as Success)
- `result missing any upload category` → **watched fail** before the fix
- Success-path mock corrected to mirror the real cloud function's payload (all five arrays, no status field)

Local: **318 unit / 77 integration / 19 snapshot** all green, lint clean.

Pre-release audit for the upcoming App Store build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)