### PR TITLE
fix: wire onPress correctly on the selected option in select-type fields

### DIFF
--- a/impacto-design-system/Extensions/FormikFields/PaperInputPicker/__tests__/PaperInputPicker.unit.test.js
+++ b/impacto-design-system/Extensions/FormikFields/PaperInputPicker/__tests__/PaperInputPicker.unit.test.js
@@ -1,0 +1,51 @@
+/**
+ * PaperInputPicker - Unit Tests
+ *
+ * Regression: the "selected" branch of a `select` field wires a
+ * `TouchableWithoutFeedback OnPress={...}` (capital O) instead of `onPress`,
+ * so React Native silently ignores it and re-pressing an already-selected
+ * option never calls setFieldValue.
+ */
+
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+// jest.setup.js globally mocks this component with a plain TextInput stub
+// (so other components' tests don't need to deal with its real complexity).
+// This suite tests the real implementation, so it must opt back out.
+jest.unmock('@impacto-design-system/Extensions/FormikFields/PaperInputPicker');
+jest.mock('@modules/i18n', () => ({ t: (key) => key }));
+
+// eslint-disable-next-line import/first
+import PaperInputPicker from '@impacto-design-system/Extensions/FormikFields/PaperInputPicker';
+
+const buildFormikProps = (values) => ({
+  values,
+  errors: {},
+  handleChange: jest.fn(() => jest.fn()),
+  handleBlur: jest.fn(() => jest.fn()),
+  setFieldValue: jest.fn(),
+});
+
+describe('PaperInputPicker - select field', () => {
+  it('calls setFieldValue when the already-selected option is pressed again', () => {
+    const formikProps = buildFormikProps({ continueProgram: 'No' });
+    const data = {
+      label: 'Do you want to continue in the program?',
+      formikKey: 'continueProgram',
+      fieldType: 'select',
+      options: [
+        { value: 'Yes', label: 'Yes', text: false },
+        { value: 'No', label: 'No', text: false },
+      ],
+    };
+
+    const { getByTestId } = render(
+      <PaperInputPicker data={data} formikProps={formikProps} customForm />
+    );
+
+    fireEvent.press(getByTestId('select-option-continueProgram-No'));
+
+    expect(formikProps.setFieldValue).toHaveBeenCalledWith('continueProgram', 'No');
+  });
+});

--- a/impacto-design-system/Extensions/FormikFields/PaperInputPicker/index.js
+++ b/impacto-design-system/Extensions/FormikFields/PaperInputPicker/index.js
@@ -283,7 +283,8 @@ function PaperInputPicker({
                 {/* selected value */}
                 {result.value === values[formikKey] && (
                   <TouchableWithoutFeedback
-                    OnPress={() => setFieldValue(formikKey, result.value)}
+                    testID={`select-option-${formikKey}-${result.value}`}
+                    onPress={() => setFieldValue(formikKey, result.value)}
                   >
                     <View style={styleButton.selected}>
                       <View style={styles.button}>
@@ -297,6 +298,7 @@ function PaperInputPicker({
                 {/* non-selected value */}
                 {result.value !== values[formikKey] && (
                   <TouchableWithoutFeedback
+                    testID={`select-option-${formikKey}-${result.value}`}
                     onPress={() => setFieldValue(formikKey, result.value)}
                   >
                     <View style={styleButton.unselected}>


### PR DESCRIPTION
TouchableWithoutFeedback used `OnPress` (capital O) on the already-selected branch of a `select` field, so React Native silently ignored it and re-pressing an already-selected option never called setFieldValue.

### Description of proposed changes
_What does this pull request accomplish? Why should it be integrated?_

### Checklist
_Put an `x` in the boxes that apply._
- [ ] My lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my changes work (if applicable)
- [ ] I have added or updated necessary documentation (if appropriate)

### Additional comments
_Is there anything else you want us to know?_
